### PR TITLE
web-ui: two decimals percentages and percentages bar added on richest addresses

### DIFF
--- a/web-ui/src/app/components/richest-addresses/richest-addresses.component.html
+++ b/web-ui/src/app/components/richest-addresses/richest-addresses.component.html
@@ -23,7 +23,14 @@
             </td>
             <td>{{item.available}} {{'label.coinName' | translate}}</td>
             <td *ngIf="ticker == null || ticker.circulatingSupply == null">{{'message.unavailable' | translate}}</td>
-            <td *ngIf="ticker != null && ticker.circulatingSupply != null">{{getPercent(item)}} %</td>
+            <td *ngIf="ticker != null && ticker.circulatingSupply != null">
+              <div
+                with="100%"
+                [ngStyle]="{'background': 'linear-gradient(to right, rgb(240, 237, 255) ' + (getPercent(item)) + '%, rgba(0,0,0,0) 0%)'}"
+              >
+                {{getPercent(item) | number:'1.2-2'}} %
+              </div>
+            </td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
Problem

Percentages were with many decimals on richest addresses view

Solution

round decimals and added a color effect to improve UI

Result
![image](https://user-images.githubusercontent.com/6043102/41559702-71abdb18-730a-11e8-9bbd-2f40ffdb61b5.png)

