### PR TITLE
web-ui: creation of pipe calendarDate (#41)

### DIFF
--- a/web-ui/src/app/app.module.ts
+++ b/web-ui/src/app/app.module.ts
@@ -44,6 +44,7 @@ import { TransactionRawComponent } from './components/transaction-raw/transactio
 import { TransactionComponent } from './components/transaction/transaction.component';
 import { BlockComponent } from './components/block/block.component';
 import { BlockRawComponent } from './components/block-raw/block-raw.component';
+import { ExplorerDatetimePipe } from './pipes/explorer-datetime.pipe';
 
 @NgModule({
   declarations: [
@@ -63,7 +64,8 @@ import { BlockRawComponent } from './components/block-raw/block-raw.component';
     TransactionRawComponent,
     TransactionComponent,
     BlockComponent,
-    BlockRawComponent
+    BlockRawComponent,
+    ExplorerDatetimePipe
   ],
   imports: [
     AppRoutingModule,

--- a/web-ui/src/app/components/address-details/address-details.component.html
+++ b/web-ui/src/app/components/address-details/address-details.component.html
@@ -65,7 +65,7 @@
             <td>
               <a routerLink="/blocks/{{item.blockhash}}">{{item.blockhash | slice:0:15}}...</a>
             </td>
-            <td>{{item.time * 1000 | date:'MMMM d, y, h:mm:ss a'}}</td>
+            <td>{{item.time * 1000 | explorerDatetime}}</td>
             <td>{{item.received >= item.sent ? '+' : ''}}{{item.received - item.sent}} {{'label.coinName' | translate}}</td>
             <td>{{item.size}} bytes</td>
           </tr>

--- a/web-ui/src/app/components/block-details/block-details.component.html
+++ b/web-ui/src/app/components/block-details/block-details.component.html
@@ -64,11 +64,11 @@
           </tr>
           <tr>
             <td>{{'label.blocktime' | translate}}</td>
-            <td>{{blockDetails.block.time * 1000 | date:'MMMM d, y, h:mm:ss a'}}</td>
+            <td>{{blockDetails.block.time * 1000 | explorerDatetime}}</td>
           </tr>
           <tr>
             <td>{{'label.medianTime' | translate}}</td>
-            <td>{{blockDetails.block.medianTime * 1000 | date:'MMMM d, y, h:mm:ss a'}}</td>
+            <td>{{blockDetails.block.medianTime * 1000 | explorerDatetime}}</td>
           </tr>
           <tr>
             <td></td>
@@ -102,7 +102,7 @@
               <th class="col-xs-2 col-sm-2 col-md-1 col-lg-1">{{blockDetails.rewards.reward.value}} {{'label.coinName' | translate}}</th>
             </tr>
           </thead>
-        
+
           <tbody>
             <tr>
               <td>{{'label.address' | translate}}</td>
@@ -121,7 +121,7 @@
               <th class="col-xs-2 col-sm-2 col-md-1 col-lg-1">{{getPoSTotalReward(blockDetails)}} {{'label.coinName' | translate}}</th>
             </tr>
           </thead>
-        
+
           <tbody>
             <tr>
               <td></td>
@@ -172,7 +172,7 @@
               <th class="col-xs-2 col-sm-2 col-md-1 col-lg-1">{{getTPoSTotalReward(blockDetails)}} {{'label.coinName' | translate}}</th>
             </tr>
           </thead>
-        
+
           <tbody>
             <tr>
               <td></td>
@@ -249,7 +249,7 @@
             <th class="col-xs-2 col-sm-2 col-md-1 col-lg-1">{{'label.transactions' | translate}}</th>
           </tr>
         </thead>
-      
+
         <tbody>
           <tr *ngFor="let item of blockDetails.block.transactions">
             <td>

--- a/web-ui/src/app/components/masternode-details/masternode-details.component.html
+++ b/web-ui/src/app/components/masternode-details/masternode-details.component.html
@@ -16,7 +16,7 @@
           </tr>
           <tr>
             <td>{{'label.lastSeen' | translate}}</td>
-            <td>{{masternode.lastSeen * 1000 | date:'MMMM d, y, h:mm:ss a'}}</td>
+            <td>{{masternode.lastSeen * 1000 | explorerDatetime}}</td>
           </tr>
           <!-- TODO: Display status when the WATCHDOG_EXPIRED bug is fixed.
           <tr>

--- a/web-ui/src/app/components/transaction-details/transaction-details.component.html
+++ b/web-ui/src/app/components/transaction-details/transaction-details.component.html
@@ -30,7 +30,7 @@
             </tr>
             <tr>
               <td>{{'label.blocktime' | translate}}</td>
-              <td>{{transaction.blocktime * 1000 | date:'MMMM d, y, h:mm:ss a'}}</td>
+              <td>{{transaction.blocktime * 1000 | explorerDatetime}}</td>
             </tr>
             <tr>
               <td>{{'label.fee' | translate}}</td>

--- a/web-ui/src/app/pipes/explorer-datetime.pipe.spec.ts
+++ b/web-ui/src/app/pipes/explorer-datetime.pipe.spec.ts
@@ -1,0 +1,39 @@
+import { ExplorerDatetimePipe } from './explorer-datetime.pipe';
+import { pipeDef } from '../../../node_modules/@angular/core/src/view';
+
+describe('ExplorerDatetimePipe', () => {
+
+  beforeAll(() => {
+    jasmine.clock().install();
+  });
+
+  afterAll(() => {
+    jasmine.clock().uninstall();
+  });
+
+  it('create an instance', () => {
+    const pipe = new ExplorerDatetimePipe('en');
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should return the parsed date when a Date object is sent', () => {
+    const pipe = new ExplorerDatetimePipe('en');
+    const date = new Date('1990-02-25');
+
+    expect(pipe.transform(date)).toMatch('February 24, 1990, 6:00:00 PM');
+  });
+
+  it('should return the parsed date when a number is sent', () => {
+    const pipe = new ExplorerDatetimePipe('en');
+    const dateInMs = new Date('August 19, 1975 23:15:30').getTime();
+
+    expect(pipe.transform(dateInMs)).toMatch('August 19, 1975, 11:15:30 PM')
+  });
+
+  it('should return the parsed date when a string is sent', () => {
+    const pipe = new ExplorerDatetimePipe('en');
+    const stringDate = 'August 19, 1975 23:15:30';
+
+    expect(pipe.transform(stringDate)).toMatch('August 19, 1975, 11:15:30 PM')
+  });
+});

--- a/web-ui/src/app/pipes/explorer-datetime.pipe.ts
+++ b/web-ui/src/app/pipes/explorer-datetime.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { DatePipe } from '@angular/common'
+
+@Pipe({
+  name: 'explorerDatetime'
+})
+export class ExplorerDatetimePipe extends DatePipe implements PipeTransform {
+  private calendarDateFormat = 'MMMM d, y, h:mm:ss a';
+
+  transform(datetime: any): string {
+    return super.transform(datetime, this.calendarDateFormat);
+  }
+}


### PR DESCRIPTION
calendarDate pipe was created and all the pipes date:'calendar format'
where replaced with calendarDate

### Problem
in a lot of components the pipe "date:'MMMM d, y, h:mm:ss a''' was used, a custom pipe
*calendarDate* was created to keep this simple

### Solution

Create the pipe *calendarDate* and replace all the "date:'MMMM d, y, h:mm:ss a'" with it
