### PR TITLE
server: Add root-cause-exception-first logging to logback.xml

### DIFF
--- a/server/conf/logback.xml
+++ b/server/conf/logback.xml
@@ -16,7 +16,7 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%level] from %logger in %thread - %message%n%rEx%xException %rEx</pattern>
+            <pattern>%date [%level] from %logger in %thread - %message%n%rEx%xException </pattern>
         </encoder>
     </appender>
 

--- a/server/conf/logback.xml
+++ b/server/conf/logback.xml
@@ -16,13 +16,13 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%level] from %logger in %thread - %message%n%xException</pattern>
+            <pattern>%date [%level] from %logger in %thread - %message%n%xException %rEx</pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%coloredLevel %logger{15} - %message%n%xException{10}</pattern>
+            <pattern>%coloredLevel %logger{15} - %message%n%xException{10} %rEx</pattern>
         </encoder>
     </appender>
 

--- a/server/conf/logback.xml
+++ b/server/conf/logback.xml
@@ -16,13 +16,13 @@
         </rollingPolicy>
 
         <encoder>
-            <pattern>%date [%level] from %logger in %thread - %message%n%xException %rEx</pattern>
+            <pattern>%date [%level] from %logger in %thread - %message%n%rEx%xException %rEx</pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%coloredLevel %logger{15} - %message%n%xException{10} %rEx</pattern>
+            <pattern>%coloredLevel %logger{15} - %message%n%rEx%xException{10} </pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Ref: Github issue #57

### Problem

> Explain the context and why you're making that change.  What is the
problem you're trying to solve? In some cases there is not a problem
and this can be thought of being the motivation for your change.

There's always trouble in finding the root cause of an exception because java prints the stack trace in last-exception-first order. Hence, root-cause-exception-first logging would help identify the root cause faster.

### Solution

> Describe the modifications you've done.

Added `%rEx` conversion word to the encodern Pattern Layout. 

Reference :
[Logback docs (Chap 6 : Layouts)](https://logback.qos.ch/manual/layouts.html#conversionWord)
[Blog/Recipe referenced in the documentation](https://www.nurkiewicz.com/2011/09/logging-exceptions-root-cause-first.html)

### Result

> What will change as a result of your pull request? Note that sometimes
this section is unnecessary because it is self-explanatory based on
the solution.

Outputs the stack trace of the exception associated with the logging event, if any. The root cause will be output first instead of the standard "root cause last"

> If you changed the UI, please include screenshots.

No
