### PR TITLE
Server: fix the getLatestTransactionBy method when sending an empty list

### DIFF
--- a/server/app/com/xsn/explorer/data/TransactionDataHandler.scala
+++ b/server/app/com/xsn/explorer/data/TransactionDataHandler.scala
@@ -4,6 +4,7 @@ import com.alexitc.playsonify.core.ApplicationResult
 import com.alexitc.playsonify.models.{FieldOrdering, PaginatedQuery, PaginatedResult}
 import com.xsn.explorer.models._
 import com.xsn.explorer.models.fields.TransactionField
+import org.scalactic.Every
 
 import scala.language.higherKinds
 
@@ -21,7 +22,7 @@ trait TransactionDataHandler[F[_]] {
       paginatedQuery: PaginatedQuery,
       ordering: FieldOrdering[TransactionField]): F[PaginatedResult[TransactionWithValues]]
 
-  def getLatestTransactionBy(addresses: List[Address]): F[Map[String, String]]
+  def getLatestTransactionBy(addresses: Every[Address]): F[Map[String, String]]
 }
 
 trait TransactionBlockingDataHandler extends TransactionDataHandler[ApplicationResult]

--- a/server/app/com/xsn/explorer/data/anorm/TransactionPostgresDataHandler.scala
+++ b/server/app/com/xsn/explorer/data/anorm/TransactionPostgresDataHandler.scala
@@ -1,14 +1,13 @@
 package com.xsn.explorer.data.anorm
 
 import javax.inject.Inject
-
 import com.alexitc.playsonify.core.ApplicationResult
 import com.alexitc.playsonify.models.{FieldOrdering, PaginatedQuery, PaginatedResult}
 import com.xsn.explorer.data.TransactionBlockingDataHandler
 import com.xsn.explorer.data.anorm.dao.TransactionPostgresDAO
 import com.xsn.explorer.models._
 import com.xsn.explorer.models.fields.TransactionField
-import org.scalactic.Good
+import org.scalactic.{Every, Good}
 import play.api.db.Database
 
 class TransactionPostgresDataHandler @Inject() (
@@ -46,7 +45,7 @@ class TransactionPostgresDataHandler @Inject() (
     Good(result)
   }
 
-  def getLatestTransactionBy(addresses: List[Address]): ApplicationResult[Map[String, String]] = withConnection { implicit conn =>
+  def getLatestTransactionBy(addresses: Every[Address]): ApplicationResult[Map[String, String]] = withConnection { implicit conn =>
     val result = transactionPostgresDAO.getLatestTransactionBy(addresses)
 
     Good(result)

--- a/server/app/com/xsn/explorer/data/anorm/dao/TransactionPostgresDAO.scala
+++ b/server/app/com/xsn/explorer/data/anorm/dao/TransactionPostgresDAO.scala
@@ -1,14 +1,15 @@
 package com.xsn.explorer.data.anorm.dao
 
 import java.sql.Connection
-import javax.inject.Inject
 
+import javax.inject.Inject
 import anorm._
 import com.alexitc.playsonify.models.{Count, FieldOrdering, PaginatedQuery}
 import com.xsn.explorer.data.anorm.interpreters.FieldOrderingSQLInterpreter
 import com.xsn.explorer.data.anorm.parsers.TransactionParsers._
 import com.xsn.explorer.models._
 import com.xsn.explorer.models.fields.TransactionField
+import org.scalactic.Every
 
 class TransactionPostgresDAO @Inject() (fieldOrderingSQLInterpreter: FieldOrderingSQLInterpreter) {
 
@@ -184,7 +185,7 @@ class TransactionPostgresDAO @Inject() (fieldOrderingSQLInterpreter: FieldOrderi
     ).as(parseTransactionOutput.*).flatten
   }
 
-  def getLatestTransactionBy(addresses: List[Address])(implicit conn: Connection): Map[String, String] = {
+  def getLatestTransactionBy(addresses: Every[Address])(implicit conn: Connection): Map[String, String] = {
 
     import SqlParser._
 
@@ -202,7 +203,7 @@ class TransactionPostgresDAO @Inject() (fieldOrderingSQLInterpreter: FieldOrderi
         |HAVING address IN ({addresses});
       """.stripMargin
     ).on(
-      'addresses -> addresses.map(_.string)
+      'addresses -> addresses.map(_.string).toList
     ).as((str("address") ~ str("txid")).map(flatten).*)
 
     result.toMap

--- a/server/app/com/xsn/explorer/data/async/TransactionFutureDataHandler.scala
+++ b/server/app/com/xsn/explorer/data/async/TransactionFutureDataHandler.scala
@@ -1,13 +1,13 @@
 package com.xsn.explorer.data.async
 
 import javax.inject.Inject
-
 import com.alexitc.playsonify.core.{FutureApplicationResult, FuturePaginatedResult}
 import com.alexitc.playsonify.models.{FieldOrdering, PaginatedQuery, PaginatedResult}
 import com.xsn.explorer.data.{TransactionBlockingDataHandler, TransactionDataHandler}
 import com.xsn.explorer.executors.DatabaseExecutionContext
 import com.xsn.explorer.models._
 import com.xsn.explorer.models.fields.TransactionField
+import org.scalactic.Every
 
 import scala.concurrent.Future
 
@@ -36,7 +36,7 @@ class TransactionFutureDataHandler @Inject() (
     blockingDataHandler.getByBlockhash(blockhash, paginatedQuery, ordering)
   }
 
-  override def getLatestTransactionBy(addresses: List[Address]): FutureApplicationResult[Map[String, String]] = Future {
+  override def getLatestTransactionBy(addresses: Every[Address]): FutureApplicationResult[Map[String, String]] = Future {
     blockingDataHandler.getLatestTransactionBy(addresses)
   }
 }

--- a/server/app/com/xsn/explorer/services/TransactionService.scala
+++ b/server/app/com/xsn/explorer/services/TransactionService.scala
@@ -1,7 +1,6 @@
 package com.xsn.explorer.services
 
 import javax.inject.Inject
-
 import com.alexitc.playsonify.core.FutureOr.Implicits.{FutureListOps, FutureOps, OrOps}
 import com.alexitc.playsonify.core.{FutureApplicationResult, FuturePaginatedResult}
 import com.alexitc.playsonify.models.{OrderingQuery, PaginatedQuery}
@@ -11,7 +10,7 @@ import com.xsn.explorer.errors._
 import com.xsn.explorer.models._
 import com.xsn.explorer.models.rpc.TransactionVIN
 import com.xsn.explorer.parsers.TransactionOrderingParser
-import org.scalactic.{Bad, Good, One, Or}
+import org.scalactic._
 import play.api.libs.json.{JsObject, JsString, JsValue}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -115,7 +114,7 @@ class TransactionService @Inject() (
     result.toFuture
   }
 
-  def getLatestTransactionBy(addresses: List[Address]): FutureApplicationResult[Map[String, String]] = {
+  def getLatestTransactionBy(addresses: Every[Address]): FutureApplicationResult[Map[String, String]] = {
     transactionFutureDataHandler.getLatestTransactionBy(addresses)
   }
 

--- a/server/app/controllers/TransactionsController.scala
+++ b/server/app/controllers/TransactionsController.scala
@@ -1,18 +1,19 @@
 package controllers
 
 import javax.inject.Inject
-
 import com.alexitc.playsonify.models.PublicContextWithModel
 import com.xsn.explorer.models.Address
 import com.xsn.explorer.models.request.SendRawTransactionRequest
 import com.xsn.explorer.services.TransactionService
-import controllers.common.{MyJsonController, MyJsonControllerComponents}
+import controllers.common.{Codecs,MyJsonController, MyJsonControllerComponents}
+import org.scalactic.Every
 
 class TransactionsController @Inject() (
     transactionService: TransactionService,
     cc: MyJsonControllerComponents)
     extends MyJsonController(cc) {
 
+  import Codecs._
   def getTransaction(txid: String) = publicNoInput { _ =>
     transactionService.getTransactionDetails(txid)
   }
@@ -25,7 +26,7 @@ class TransactionsController @Inject() (
     transactionService.sendRawTransaction(ctx.model.hex)
   }
 
-  def getLatestByAddresses() = publicWithInput { ctx: PublicContextWithModel[List[Address]] =>
+  def getLatestByAddresses() = publicWithInput { ctx: PublicContextWithModel[Every[Address]] =>
     transactionService.getLatestTransactionBy(ctx.model)
   }
 }

--- a/server/app/controllers/common/Codecs.scala
+++ b/server/app/controllers/common/Codecs.scala
@@ -1,0 +1,19 @@
+package controllers.common
+
+import org.scalactic.Every
+import play.api.libs.json._
+
+object Codecs {
+
+  implicit def everyReads[T](implicit readsT: Reads[T]): Reads[Every[T]] = Reads[Every[T]] { json =>
+    json
+      .validate[List[T]]
+      .flatMap { list =>
+        Every.from(list)
+          .map(JsSuccess.apply(_))
+          .getOrElse {
+            JsError.apply("A non-empty list is expected")
+          }
+      }
+  }
+}

--- a/server/test/com/xsn/explorer/data/TransactionPostgresDataHandlerSpec.scala
+++ b/server/test/com/xsn/explorer/data/TransactionPostgresDataHandlerSpec.scala
@@ -11,7 +11,7 @@ import com.xsn.explorer.helpers.{BlockLoader, TransactionLoader}
 import com.xsn.explorer.models._
 import com.xsn.explorer.models.fields.TransactionField
 import com.xsn.explorer.models.rpc.Block
-import org.scalactic.{Good, One, Or}
+import org.scalactic.{Every, Good, One, Or}
 import org.scalatest.BeforeAndAfter
 
 class TransactionPostgresDataHandlerSpec extends PostgresDataHandlerSpec with BeforeAndAfter {
@@ -307,7 +307,7 @@ class TransactionPostgresDataHandlerSpec extends PostgresDataHandlerSpec with Be
         "XdJnCKYNwzCz8ATv8Eu75gonaHyfr9qXg9" -> "1e591eae200f719344fc5df0c4286e3fb191fb8a645bdf054f9b36a856fce41e"
       )
 
-      val addresses = List(
+      val addresses = Every(
         createAddress("XdJnCKYNwzCz8ATv8Eu75gonaHyfr9qXg9"),
         createAddress("XcqpUChZhNkVDgQqFF9U4DdewDGUMWwG53"),
         createAddress("XcqpUChZhNkVDgQqFF9U4DdewDGUMWwG54"),

--- a/server/test/com/xsn/explorer/helpers/TransactionDummyDataHandler.scala
+++ b/server/test/com/xsn/explorer/helpers/TransactionDummyDataHandler.scala
@@ -5,6 +5,7 @@ import com.alexitc.playsonify.models.{FieldOrdering, PaginatedQuery, PaginatedRe
 import com.xsn.explorer.data.TransactionBlockingDataHandler
 import com.xsn.explorer.models._
 import com.xsn.explorer.models.fields.TransactionField
+import org.scalactic.Every
 
 class TransactionDummyDataHandler extends TransactionBlockingDataHandler {
 
@@ -14,5 +15,5 @@ class TransactionDummyDataHandler extends TransactionBlockingDataHandler {
 
   override def getByBlockhash(blockhash: Blockhash, paginatedQuery: PaginatedQuery, ordering: FieldOrdering[TransactionField]): ApplicationResult[PaginatedResult[TransactionWithValues]] = ???
 
-  override def getLatestTransactionBy(addresses: List[Address]): ApplicationResult[Map[String, String]] = ???
+  override def getLatestTransactionBy(addresses: Every[Address]): ApplicationResult[Map[String, String]] = ???
 }


### PR DESCRIPTION

### Problem

The TransactionPostgresDAO.scala#getLatestTransactionBy method fails on empty lists

### Solution

 change the argument type from List[Address] to Every[Address], then, change the upper layers to parse the input and return an error if an empty list is received.

added the tests for sending an empty list and retrieving valid data


### Result

if an empty list is received, the server returns an error message 