### PR TITLE
server: Add documentation to a probable issue when running sbt test

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -13,3 +13,7 @@
 
 ## Test
 Run the `sbt test` command to execute the tests.
+
+In case of failed tests, verify that:
+- The docker remote API is enabled (this command must succeed `curl localhost:4243/containers/json` on linux).
+- Try running `DOCKER_HOST=localhost:4243 sbt test` instead.


### PR DESCRIPTION
### Problem

Running command `sbt test`, Docker container fails to initialize because of its remote API.

### Solution

Included documentation on README.md file about the issue and an alternative command to use instead.

### Result

Increase the documentation and get solutions to new users with similar cases.