### PR TITLE
web-ui: collapse similar inputs while displaying a transaction Fix #49

### DIFF
--- a/web-ui/src/app/components/transaction-details/transaction-details.component.html
+++ b/web-ui/src/app/components/transaction-details/transaction-details.component.html
@@ -43,15 +43,15 @@
 
     <div class="row">
       <!-- Input -->
-      <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
+      <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
         <table class="table table-condensed table-bordered table-striped table-hover">
           <thead>
             <tr *ngIf="transaction.input == null">
-              <th class="col-xs-3 col-sm-3 col-md-2 col-lg-2">{{'label.noInput' | translate}}</th>
+              <th class="col-xs-4 col-sm-4 col-md-3 col-lg-3">{{'label.noInput' | translate}}</th>
               <th class="col-xs-5 col-sm-5 col-md-4 col-lg-4"></th>
             </tr>
             <tr *ngIf="transaction.input != null">
-              <th class="col-xs-3 col-sm-3 col-md-2 col-lg-2">{{'label.from' | translate}}</th>
+              <th class="col-xs-4 col-sm-4 col-md-3 col-lg-3">{{'label.from' | translate}}</th>
               <th class="col-xs-5 col-sm-5 col-md-4 col-lg-4"></th>
             </tr>
           </thead>
@@ -61,8 +61,11 @@
               <td>{{'label.coinbase' | translate}}</td>
               <td></td>
             </tr>
-            <tr *ngFor="let item of transaction.input">
-              <td>
+            <tr *ngFor="let item of collapsedInput">
+              <td *ngIf="count(item.address, transaction.input) != 1">
+                <a routerLink="/addresses/{{item.address}}">{{item.address}}</a> ({{count(item.address, transaction.input)}})
+              </td>
+              <td *ngIf="count(item.address, transaction.input) == 1">
                 <a routerLink="/addresses/{{item.address}}">{{item.address}}</a>
               </td>
               <td>{{item.value}} {{'label.coinName' | translate}}</td>
@@ -77,8 +80,11 @@
               <td><strong>{{'label.output' | translate}}</strong></td>
               <td></td>
             </tr>
-            <tr *ngFor="let item of transaction.output">
-              <td>
+            <tr *ngFor="let item of collapsedOutput">
+              <td *ngIf="count(item.address, transaction.output) != 1">
+                <a routerLink="/addresses/{{item.address}}">{{item.address}}</a> ({{count(item.address, transaction.output)}})
+              </td>
+              <td *ngIf="count(item.address, transaction.output) == 1">
                 <a routerLink="/addresses/{{item.address}}">{{item.address}}</a>
               </td>
               <td>{{item.value}} {{'label.coinName' | translate}}</td>

--- a/web-ui/src/app/models/transaction.ts
+++ b/web-ui/src/app/models/transaction.ts
@@ -12,7 +12,7 @@ export class Transaction {
   received: number;
 }
 
-class TransactionValue {
+export class TransactionValue {
   address: string;
   value: number;
 }


### PR DESCRIPTION
The transaction-details.component.ts add new private functions (collapseRepeatedRows, pushAccumulatedTransaction)
to collapse the rows in From and Receivers forms in Transaction screen.

It exports the TransactionValue class in the transaction.ts module.

### Problem
Displaying list transactions could have repeated address and it's expected to collapse while sums their values and show a count of collapsed rows.

### Solution
Add new functionality to transaction component to collapse into one the repeated addresses, summing the value and add a ($count) format to an address name.

### Result
The feature was implemented in the transactions screen.

before behaviour
![screenshot from 2019-01-10 12-36-27](https://user-images.githubusercontent.com/10504648/50992457-7defca80-14d4-11e9-9639-184ec72b4ce1.png)

after behavior
![after](https://user-images.githubusercontent.com/10504648/50997323-7da9fc00-14e1-11e9-990c-5fae7577274f.png)
