### PR TITLE
web-ui: Update explorerCurrency pipe to fix 8 decimals

### DIFF
--- a/web-ui/src/app/pipes/explorer-currency.pipe.ts
+++ b/web-ui/src/app/pipes/explorer-currency.pipe.ts
@@ -6,6 +6,13 @@ import { Config } from '../config';
 })
 export class ExplorerCurrencyPipe implements PipeTransform {
   transform(currency: any): string {
-    return `${ currency } ${ Config.currentCurrency }`;
+    let currencyNumber: number;
+    if (typeof(currency) === 'number') {
+      currencyNumber = currency;
+    } else if (typeof(currency) === 'string') {
+      currencyNumber = parseFloat(currency);
+    }
+
+    return `${ currencyNumber.toFixed(8) } ${ Config.currentCurrency }`;
   }
 }


### PR DESCRIPTION
### Problem

Some operations with numbers get inexact results
example:

current operation result
0.02098747 - (0.01098581 + 0.01) = 0.00000166000000000055
getting a 0.00000000000000000055 overcome (float issue)

### Solution

The explorerCurrency pipe fix the currency value to 8 decimals

### Result

Currency values are displayed fixed to 8 decimals

before:
![before](https://user-images.githubusercontent.com/10504648/51215950-ecbb9200-18df-11e9-83ca-143005a3f570.png)

after:
![after](https://user-images.githubusercontent.com/10504648/51215962-f0e7af80-18df-11e9-8c01-70a6a024600e.png)
