### PR TITLE
server: Update endpoint "GET /block-headers/:query"

### DIFF
--- a/server/app/com/xsn/explorer/data/BlockDataHandler.scala
+++ b/server/app/com/xsn/explorer/data/BlockDataHandler.scala
@@ -30,6 +30,8 @@ trait BlockDataHandler[F[_]] {
   ): F[List[BlockHeader]]
 
   def getHeader(blockhash: Blockhash): F[BlockHeader]
+
+  def getHeader(height: Height): F[BlockHeader]
 }
 
 trait BlockBlockingDataHandler extends BlockDataHandler[ApplicationResult]

--- a/server/app/com/xsn/explorer/data/anorm/BlockPostgresDataHandler.scala
+++ b/server/app/com/xsn/explorer/data/anorm/BlockPostgresDataHandler.scala
@@ -74,4 +74,10 @@ class BlockPostgresDataHandler @Inject()(override val database: Database, blockP
       Or.from(maybe, One(BlockNotFoundError))
     }
 
+  override def getHeader(height: Height): ApplicationResult[BlockHeader] =
+    withConnection { implicit conn =>
+      val maybe = blockPostgresDAO.getHeader(height)
+      Or.from(maybe, One(BlockNotFoundError))
+    }
+
 }

--- a/server/app/com/xsn/explorer/data/async/BlockFutureDataHandler.scala
+++ b/server/app/com/xsn/explorer/data/async/BlockFutureDataHandler.scala
@@ -57,4 +57,7 @@ class BlockFutureDataHandler @Inject()(blockBlockingDataHandler: BlockBlockingDa
     blockBlockingDataHandler.getHeader(blockhash)
   }
 
+  override def getHeader(height: Height): FutureApplicationResult[BlockHeader] = Future {
+    blockBlockingDataHandler.getHeader(height)
+  }
 }

--- a/server/app/com/xsn/explorer/services/BlockService.scala
+++ b/server/app/com/xsn/explorer/services/BlockService.scala
@@ -60,6 +60,10 @@ class BlockService @Inject()(
     result.toFuture
   }
 
+  def getBlockHeader(height: Height): FutureApplicationResult[BlockHeader] = {
+    blockDataHandler.getHeader(height)
+  }
+
   private def canCacheResult(
       ordering: OrderingCondition,
       expectedSize: Int,

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -18,7 +18,7 @@ GET   /addresses/:address/utxos                      controllers.AddressesContro
 
 GET   /blocks                            controllers.BlocksController.getLatestBlocks()
 GET   /blocks/headers                    controllers.BlocksController.getBlockHeaders(lastSeenHash: Option[String], limit: Int ?= 10, order: String ?= "asc")
-GET   /block-headers/:blockhash          controllers.BlocksController.getBlockHeader(blockhash: String)
+GET   /block-headers/:query              controllers.BlocksController.getBlockHeader(query: String)
 GET   /blocks/estimate-fee               controllers.BlocksController.estimateFee(nBlocks: Int ?= 1)
 
 GET   /blocks/:query                     controllers.BlocksController.getDetails(query: String)

--- a/server/test/com/xsn/explorer/data/BlockPostgresDataHandlerSpec.scala
+++ b/server/test/com/xsn/explorer/data/BlockPostgresDataHandlerSpec.scala
@@ -219,7 +219,7 @@ class BlockPostgresDataHandlerSpec extends PostgresDataHandlerSpec with BeforeAn
 
   "getHeader" should {
 
-    "return the blockHeader" in {
+    "return the blockHeader by blockhash" in {
       val block = BlockLoader
         .get("1ca318b7a26ed67ca7c8c9b5069d653ba224bf86989125d1dfbb0973b7d6a5e0")
         .copy(previousBlockhash = None, nextBlockhash = None)
@@ -227,6 +227,19 @@ class BlockPostgresDataHandlerSpec extends PostgresDataHandlerSpec with BeforeAn
 
       val header = block.into[BlockHeader.Simple].transform
       val result = dataHandler.getHeader(block.hash)
+
+      result.isGood mustEqual true
+      matches(header, result.get)
+    }
+
+    "return the blockHeader by height" in {
+      val block = BlockLoader
+        .get("00000c822abdbb23e28f79a49d29b41429737c6c7e15df40d1b1f1b35907ae34")
+        .copy(previousBlockhash = None, nextBlockhash = None)
+      insert(block).isGood mustEqual true
+
+      val header = block.into[BlockHeader.Simple].transform
+      val result = dataHandler.getHeader(block.height)
 
       result.isGood mustEqual true
       matches(header, result.get)


### PR DESCRIPTION
Retrieves a block header by its height or by its blockhash

### Problem

There is no way to retrieve a blockhash by height

### Solution

Change the endpoint "GET /block-headers/:blockhash" to "GET /block-headers/:query"
and allow a block hash or a height in the parameter
