### PR TITLE
server: update endpoint "GET /block-headers/:query?includeFilter=true"

### DIFF
--- a/server/app/com/xsn/explorer/data/BlockDataHandler.scala
+++ b/server/app/com/xsn/explorer/data/BlockDataHandler.scala
@@ -29,9 +29,9 @@ trait BlockDataHandler[F[_]] {
       lastSeenHash: Option[Blockhash]
   ): F[List[BlockHeader]]
 
-  def getHeader(blockhash: Blockhash): F[BlockHeader]
+  def getHeader(blockhash: Blockhash, includeFilter: Boolean): F[BlockHeader]
 
-  def getHeader(height: Height): F[BlockHeader]
+  def getHeader(height: Height, includeFilter: Boolean): F[BlockHeader]
 }
 
 trait BlockBlockingDataHandler extends BlockDataHandler[ApplicationResult]

--- a/server/app/com/xsn/explorer/data/anorm/BlockPostgresDataHandler.scala
+++ b/server/app/com/xsn/explorer/data/anorm/BlockPostgresDataHandler.scala
@@ -68,15 +68,15 @@ class BlockPostgresDataHandler @Inject()(override val database: Database, blockP
     Good(result)
   }
 
-  override def getHeader(blockhash: Blockhash): ApplicationResult[BlockHeader] =
+  override def getHeader(blockhash: Blockhash, includeFilter: Boolean): ApplicationResult[BlockHeader] =
     withConnection { implicit conn =>
-      val maybe = blockPostgresDAO.getHeader(blockhash)
+      val maybe = blockPostgresDAO.getHeader(blockhash, includeFilter)
       Or.from(maybe, One(BlockNotFoundError))
     }
 
-  override def getHeader(height: Height): ApplicationResult[BlockHeader] =
+  override def getHeader(height: Height, includeFilter: Boolean): ApplicationResult[BlockHeader] =
     withConnection { implicit conn =>
-      val maybe = blockPostgresDAO.getHeader(height)
+      val maybe = blockPostgresDAO.getHeader(height, includeFilter)
       Or.from(maybe, One(BlockNotFoundError))
     }
 

--- a/server/app/com/xsn/explorer/data/async/BlockFutureDataHandler.scala
+++ b/server/app/com/xsn/explorer/data/async/BlockFutureDataHandler.scala
@@ -53,11 +53,11 @@ class BlockFutureDataHandler @Inject()(blockBlockingDataHandler: BlockBlockingDa
     blockBlockingDataHandler.getHeaders(limit, orderingCondition, lastSeenHash)
   }
 
-  override def getHeader(blockhash: Blockhash): FutureApplicationResult[BlockHeader] = Future {
-    blockBlockingDataHandler.getHeader(blockhash)
+  override def getHeader(blockhash: Blockhash, includeFilter: Boolean): FutureApplicationResult[BlockHeader] = Future {
+    blockBlockingDataHandler.getHeader(blockhash, includeFilter)
   }
 
-  override def getHeader(height: Height): FutureApplicationResult[BlockHeader] = Future {
-    blockBlockingDataHandler.getHeader(height)
+  override def getHeader(height: Height, includeFilter: Boolean): FutureApplicationResult[BlockHeader] = Future {
+    blockBlockingDataHandler.getHeader(height, includeFilter)
   }
 }

--- a/server/app/com/xsn/explorer/services/BlockService.scala
+++ b/server/app/com/xsn/explorer/services/BlockService.scala
@@ -51,17 +51,17 @@ class BlockService @Inject()(
     result.toFuture
   }
 
-  def getBlockHeader(blockhashString: String): FutureApplicationResult[BlockHeader] = {
+  def getBlockHeader(blockhashString: String, includeFilter: Boolean): FutureApplicationResult[BlockHeader] = {
     val result = for {
       blockhash <- blockhashValidator.validate(blockhashString).toFutureOr
-      header <- blockDataHandler.getHeader(blockhash).toFutureOr
+      header <- blockDataHandler.getHeader(blockhash, includeFilter).toFutureOr
     } yield header
 
     result.toFuture
   }
 
-  def getBlockHeader(height: Height): FutureApplicationResult[BlockHeader] = {
-    blockDataHandler.getHeader(height)
+  def getBlockHeader(height: Height, includeFilter: Boolean): FutureApplicationResult[BlockHeader] = {
+    blockDataHandler.getHeader(height, includeFilter)
   }
 
   private def canCacheResult(

--- a/server/app/controllers/BlocksController.scala
+++ b/server/app/controllers/BlocksController.scala
@@ -46,14 +46,14 @@ class BlocksController @Inject()(
    * is not a valid height, we assume it might be a blockhash and try to
    * retrieve the blockHeader by blockhash.
    */
-  def getBlockHeader(query: String) = public { _ =>
+  def getBlockHeader(query: String, includeFilter: Boolean) = public { _ =>
     val (cache, resultF) = Try(query.toInt)
       .map(Height.apply)
       .map { value =>
-        "no-store" -> blockService.getBlockHeader(value)
+        "no-store" -> blockService.getBlockHeader(value, includeFilter)
       }
       .getOrElse {
-        "public, max-age=31536000" -> blockService.getBlockHeader(query)
+        "public, max-age=31536000" -> blockService.getBlockHeader(query, includeFilter)
       }
 
     resultF.toFutureOr.map { value =>

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -18,7 +18,7 @@ GET   /addresses/:address/utxos                      controllers.AddressesContro
 
 GET   /blocks                            controllers.BlocksController.getLatestBlocks()
 GET   /blocks/headers                    controllers.BlocksController.getBlockHeaders(lastSeenHash: Option[String], limit: Int ?= 10, order: String ?= "asc")
-GET   /block-headers/:query              controllers.BlocksController.getBlockHeader(query: String)
+GET   /block-headers/:query              controllers.BlocksController.getBlockHeader(query: String, includeFilter: Boolean ?= false)
 GET   /blocks/estimate-fee               controllers.BlocksController.estimateFee(nBlocks: Int ?= 1)
 
 GET   /blocks/:query                     controllers.BlocksController.getDetails(query: String)


### PR DESCRIPTION
The endpoint for retrieving the block header allows specifying whether it needs the filter

### Problem

When you retrieve a blockheader the filter is always present 

### Solution
update endpoint "GET /block-headers/:query?includeFilter=true" to specify if needs filter 

