### PR TITLE
server: Fix block reward computation

### DIFF
--- a/server/test/controllers/BlocksControllerSpec.scala
+++ b/server/test/controllers/BlocksControllerSpec.scala
@@ -1,25 +1,22 @@
 package controllers
 
-import com.alexitc.playsonify.models.ordering.FieldOrdering
 import com.alexitc.playsonify.models.pagination._
 import com.alexitc.playsonify.play.PublicErrorRenderer
 import com.xsn.explorer.data.{BlockBlockingDataHandler, TransactionBlockingDataHandler}
 import com.xsn.explorer.gcs.{GolombCodedSet, UnsignedByte}
 import com.xsn.explorer.helpers._
-import com.xsn.explorer.models._
-import com.xsn.explorer.models.fields.TransactionField
 import com.xsn.explorer.models.persisted.{BlockHeader, Transaction}
-import com.xsn.explorer.models.rpc.{Block, TransactionVIN}
+import com.xsn.explorer.models.rpc.Block
 import com.xsn.explorer.models.values.{Blockhash, Confirmations, Height, Size}
 import com.xsn.explorer.services.XSNService
 import controllers.common.MyAPISpec
+import io.scalaland.chimney.dsl._
 import org.mockito.ArgumentMatchersSugar._
 import org.mockito.MockitoSugar._
 import org.scalactic.Good
 import play.api.inject.bind
-import play.api.libs.json.{JsValue}
+import play.api.libs.json.JsValue
 import play.api.test.Helpers._
-import io.scalaland.chimney.dsl._
 
 class BlocksControllerSpec extends MyAPISpec {
 

--- a/server/test/resources/transactions/d868e31f5161d049b8afdabedeefe8ccf8caef15d1f80ef34405e97110feebc6
+++ b/server/test/resources/transactions/d868e31f5161d049b8afdabedeefe8ccf8caef15d1f80ef34405e97110feebc6
@@ -1,0 +1,31 @@
+{
+  "txid": "d868e31f5161d049b8afdabedeefe8ccf8caef15d1f80ef34405e97110feebc6",
+  "hash": "d868e31f5161d049b8afdabedeefe8ccf8caef15d1f80ef34405e97110feebc6",
+  "version": 1,
+  "size": 65,
+  "vsize": 65,
+  "weight": 260,
+  "locktime": 0,
+  "vin": [
+    {
+      "coinbase": "02d8590101",
+      "sequence": 4294967295
+    }
+  ],
+  "vout": [
+    {
+      "value": 0,
+      "n": 0,
+      "scriptPubKey": {
+        "asm": "",
+        "hex": "",
+        "type": "nonstandard"
+      }
+    }
+  ],
+  "hex": "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0502d8590101ffffffff0100000000000000000000000000",
+  "blockhash": "1ca318b7a26ed67ca7c8c9b5069d653ba224bf86989125d1dfbb0973b7d6a5e0",
+  "confirmations": 627804,
+  "time": 1521784448,
+  "blocktime": 1521784448
+}

--- a/server/test/resources/transactions/df275d713fcf5e78e7e8369d640201d46736c0d2255e31ce45bd5aa0206f861f
+++ b/server/test/resources/transactions/df275d713fcf5e78e7e8369d640201d46736c0d2255e31ce45bd5aa0206f861f
@@ -1,0 +1,31 @@
+{
+  "txid": "df275d713fcf5e78e7e8369d640201d46736c0d2255e31ce45bd5aa0206f861f",
+  "hash": "df275d713fcf5e78e7e8369d640201d46736c0d2255e31ce45bd5aa0206f861f",
+  "version": 1,
+  "size": 65,
+  "vsize": 65,
+  "weight": 260,
+  "locktime": 0,
+  "vin": [
+    {
+      "coinbase": "02e8030101",
+      "sequence": 4294967295
+    }
+  ],
+  "vout": [
+    {
+      "value": 0,
+      "n": 0,
+      "scriptPubKey": {
+        "asm": "",
+        "hex": "",
+        "type": "nonstandard"
+      }
+    }
+  ],
+  "hex": "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0502e8030101ffffffff0100000000000000000000000000",
+  "blockhash": "25762bf01143f7fe34912c926e0b95528b082c6323de35516de0fc321f5d8058",
+  "confirmations": 649812,
+  "time": 1520327156,
+  "blocktime": 1520327156
+}


### PR DESCRIPTION
Remove the isPoW, isPoS, and isTPoS methods from the rpc.Block.

### Problem
The endpoint   GET   /blocks/:query  returns an error when cannot compute the reward

### Solution
BlockService#getDetailsPrivate should return the block even if it wasn't able to compute the rewards
Remove the isPoW, isPoS, and isTPoS methods from the rpc.Block.
