### PR TITLE
web-ui: Add a column for label the richest addresses

### DIFF
--- a/web-ui/src/app/app.component.ts
+++ b/web-ui/src/app/app.component.ts
@@ -145,6 +145,7 @@ export class AppComponent implements OnInit {
       'label.richestAddresses': 'Richest addresses',
       'label.masternodes': 'Masternodes',
       'label.percentOfCoins': 'Percent of coins',
+      'label.addressLabel': 'Label',
       'label.protocol': 'Protocol',
       'label.status': 'Status',
       'label.lastSeen': 'Last seen',

--- a/web-ui/src/app/components/address-details/address-details.component.html
+++ b/web-ui/src/app/components/address-details/address-details.component.html
@@ -4,7 +4,9 @@
   </div>
   <div *ngIf="address != null">
     <div class="row">
-      <h2 class="col-xs-12">{{'label.address' | translate}}</h2>
+        <h2 *ngIf="!addressLabel[addressString]" class="col-xs-12">{{'label.address' | translate}}</h2>
+        <h2 *ngIf="addressLabel[addressString]" class="col-xs-12">{{ addressLabel[addressString]}}</h2>
+
     </div>
     <div class="row">
       <div class="col-xs-12 col-md-4">

--- a/web-ui/src/app/components/address-details/address-details.component.ts
+++ b/web-ui/src/app/components/address-details/address-details.component.ts
@@ -9,6 +9,7 @@ import { ErrorService } from '../../services/error.service';
 import { LightWalletTransaction } from '../..//models/light-wallet-transaction';
 
 import { getNumberOfRowsForScreen } from '../../utils';
+import { addressLabels } from '../../config';
 
 @Component({
   selector: 'app-address-details',
@@ -19,6 +20,7 @@ export class AddressDetailsComponent implements OnInit {
 
   address: Balance;
   addressString: string;
+  addressLabel = addressLabels;
 
   // pagination
   limit = 30;

--- a/web-ui/src/app/components/richest-addresses/richest-addresses.component.html
+++ b/web-ui/src/app/components/richest-addresses/richest-addresses.component.html
@@ -11,6 +11,7 @@
           <th class="col-xs-2 col-md-1">{{'label.address' | translate}}</th>
           <th class="col-xs-2 col-md-1">{{'label.amount' | translate}}</th>
           <th class="col-xs-2 col-md-1">{{'label.percentOfCoins' | translate}}</th>
+          <th class="col-xs-2 col-md-1">{{'label.addressLabel' | translate}}</th>
         </tr>
       </thead>
 
@@ -34,6 +35,9 @@
               >
                 {{getPercent(item) | number:'1.2-2'}} %
               </div>
+            </td>
+            <td>
+              <span class="label label-primary">{{addressLabel[item.address]}}</span>
             </td>
           </tr>
       </tbody>

--- a/web-ui/src/app/components/richest-addresses/richest-addresses.component.ts
+++ b/web-ui/src/app/components/richest-addresses/richest-addresses.component.ts
@@ -2,9 +2,6 @@
 import {tap} from 'rxjs/operators';
 import { Component, OnInit, OnDestroy, HostListener } from '@angular/core';
 
-
-
-
 import { Balance } from '../../models/balance';
 
 import { BalancesService } from '../../services/balances.service';
@@ -12,6 +9,7 @@ import { TickerService } from '../../services/ticker.service';
 import { ServerStats } from '../../models/ticker';
 
 import { getNumberOfRowsForScreen } from '../../utils';
+import { addressLabels } from '../../config';
 
 @Component({
   selector: 'app-richest-addresses',
@@ -26,6 +24,8 @@ export class RichestAddressesComponent implements OnInit {
   // pagination
   limit = 30;
   items: Balance[] = [];
+
+  addressLabel = addressLabels;
 
   constructor(
     private balancesService: BalancesService,

--- a/web-ui/src/app/config.ts
+++ b/web-ui/src/app/config.ts
@@ -1,3 +1,9 @@
 export class Config {
     static currentCurrency = 'XSN';
 }
+
+export const addressLabels = {
+    '7jqffPwhzkVGbYFf525muhas6uVrhERwAm': 'Cryptopia',
+    '7iYWrbBhYczSYPZ3Naesd9Yk4X5qn4dNAg': 'Livecoin',
+    'Xi1BEVHFRYg1QQfrNJF8L9yXvREAADxCLk': 'Stakenet.io Cloud Staking'
+};


### PR DESCRIPTION
Add a column in the richest-addresses component

### Problem

There is no way to identify some richest addresses 

### Solution

- Create a constant map (address -> label).
- On the richest addresses view, add a column rendering the label if available.
- On the address view, display the label if it is available.

### Result
![Screenshot from 2019-06-11 13-24-28](https://user-images.githubusercontent.com/11052423/59301366-abd96680-8c4e-11e9-81d1-06905333be7c.png)

![Screenshot from 2019-06-11 15-03-46](https://user-images.githubusercontent.com/11052423/59306744-37a4c000-8c5a-11e9-970e-c6646173eefa.png)

