### PR TITLE
server: fixed SipHashKey.fromBtcutil(hash: Blockhash) implementation

### DIFF
--- a/server/app/com/xsn/explorer/gcs/SipHashKey.scala
+++ b/server/app/com/xsn/explorer/gcs/SipHashKey.scala
@@ -37,14 +37,6 @@ object SipHashKey {
   }
 
   def fromBtcutil(hash: Blockhash): SipHashKey = {
-    val bytes = hash.string
-      .take(32)
-      .grouped(2)
-      .map { hex =>
-        Integer.parseInt(hex, 16).asInstanceOf[Byte]
-      }
-      .toList
-
-    fromBtcutil(bytes)
+    fromBtcutil(hash.toBytesLE.take(16))
   }
 }

--- a/server/app/com/xsn/explorer/models/values/Blockhash.scala
+++ b/server/app/com/xsn/explorer/models/values/Blockhash.scala
@@ -3,7 +3,18 @@ package com.xsn.explorer.models.values
 import com.alexitc.playsonify.models.WrappedString
 import play.api.libs.json._
 
-class Blockhash private (val string: String) extends AnyVal with WrappedString
+class Blockhash private (val string: String) extends AnyVal with WrappedString {
+
+  def toBytesLE: List[Byte] = {
+    string
+      .grouped(2)
+      .toList
+      .reverse
+      .map { hex =>
+        Integer.parseInt(hex, 16).asInstanceOf[Byte]
+      }
+  }
+}
 
 object Blockhash {
 

--- a/server/test/com/xsn/explorer/gcs/SipHashKeySpec.scala
+++ b/server/test/com/xsn/explorer/gcs/SipHashKeySpec.scala
@@ -18,9 +18,25 @@ class SipHashKeySpec extends WordSpec {
 
     "allow to use a blockhash" in {
       val blockhash = Blockhash.from("00000b59875e80b0afc6c657bc5318d39e03532b7d97fb78a4c7bd55c4840c32").get
-      val expected = "SipHashKey(12718269283101769728, 15210999809835452079)"
+      val expected = "SipHashKey(11873667118652460082, 11386035729178557304)"
       val key = SipHashKey.fromBtcutil(blockhash)
       key.toString must be(expected)
+    }
+
+    "calculate the same key as btcutil" in {
+
+      /**
+       * The blockhash and the expected key were taken from btcutil tests
+       * see https://github.com/btcsuite/btcutil/blob/9e5f4b9a998d263e3ce9c56664a7816001ac8000/gcs/builder/builder_test.go#L46 for the key
+       * and https://github.com/btcsuite/btcutil/blob/9e5f4b9a998d263e3ce9c56664a7816001ac8000/gcs/builder/builder_test.go#L49 for the hash
+       */
+      val blockhash = Blockhash.from("000000000000000000496d7ff9bd2c96154a8d64260e8b3b411e625712abb14c").get
+      val expectedKey = SipHashKey.fromBtcutil(
+        List(0x4c, 0xb1, 0xab, 0x12, 0x57, 0x62, 0x1e, 0x41, 0x3b, 0x8b, 0x0e, 0x26, 0x64, 0x8d, 0x4a,
+          0x15).map(_.asInstanceOf[Byte])
+      )
+      val key = SipHashKey.fromBtcutil(blockhash)
+      key.toString must be(expectedKey.toString)
     }
   }
 }

--- a/server/test/com/xsn/explorer/models/values/BlockhashSpec.scala
+++ b/server/test/com/xsn/explorer/models/values/BlockhashSpec.scala
@@ -1,0 +1,17 @@
+package com.xsn.explorer.models.values
+
+import org.scalatest.WordSpec
+import org.scalatest.MustMatchers._
+
+class BlockhashSpec extends WordSpec {
+  val blockhash = Blockhash.from("000000000000000000496d7ff9bd2c96154a8d64260e8b3b411e625712abb14c").get
+
+  "Getting the blockhash bytes in little endian" should {
+    "return the correct bytes" in {
+      val expectedBytes: List[Byte] = List(76, -79, -85, 18, 87, 98, 30, 65, 59, -117, 14, 38, 100, -115, 74, 21, -106,
+        44, -67, -7, 127, 109, 73, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+
+      blockhash.toBytesLE must be(expectedBytes)
+    }
+  }
+}


### PR DESCRIPTION
fixes SipHashKey.fromBtcutil(hash: Blockhash) calculating a different key that btcutil as mentioned in #101 