### PR TITLE
web-ui: Explain what Total supply and Circulating supply stand for

### DIFF
--- a/web-ui/src/app/app.component.ts
+++ b/web-ui/src/app/app.component.ts
@@ -1,5 +1,5 @@
 
-import {distinctUntilChanged} from 'rxjs/operators';
+import { distinctUntilChanged } from 'rxjs/operators';
 import { Component, OnInit } from '@angular/core';
 
 import { Router, NavigationEnd } from '@angular/router';
@@ -83,6 +83,8 @@ export class AppComponent implements OnInit {
       'message.loadingLatestBlocks': 'Loading latest blocks...',
       'message.loadingRichestAddresses': 'Loading richest addresses...',
       'message.transactionsNotAvailable': 'The transactions are not available, please try again in some minutes',
+      'message.totalSupply': 'The total number of coins generated (excluding the burned coins)',
+      'message.circulatingSupply': 'The total number of coins that are circulating (excludes the burned coins, and the treasury)',
 
       // error messages
       'error.nothingFound': 'That doesn\'t seem to be a valid address, nor valid block, neither a valid transaction or ip address',

--- a/web-ui/src/app/components/ticker/ticker.component.css
+++ b/web-ui/src/app/components/ticker/ticker.component.css
@@ -1,0 +1,6 @@
+span.help {
+  color: blue;
+  cursor: help;
+  font-size: 16px;
+  float: right;
+}

--- a/web-ui/src/app/components/ticker/ticker.component.html
+++ b/web-ui/src/app/components/ticker/ticker.component.html
@@ -3,7 +3,9 @@
     <div class="col-xs-12 col-sm-6 col-md-3">
       <div class="panel panel-default">
         <div class="panel-heading">
+
           {{'label.totalSupply' | translate}}
+          <span class="help" [title]="'message.totalSupply' | translate">?</span>
         </div>
 
         <div class="panel-body">
@@ -21,6 +23,7 @@
       <div class="panel panel-default">
         <div class="panel-heading">
           {{'label.circulatingSupply' | translate}}
+          <span class="help" [title]="'message.circulatingSupply' | translate">?</span>
         </div>
 
         <div class="panel-body">

--- a/web-ui/src/app/components/ticker/ticker.component.ts
+++ b/web-ui/src/app/components/ticker/ticker.component.ts
@@ -3,6 +3,7 @@ import { Component, OnInit } from '@angular/core';
 import { TickerService } from '../../services/ticker.service';
 import { ServerStats } from '../../models/ticker';
 
+
 @Component({
   selector: 'app-ticker',
   templateUrl: './ticker.component.html',

--- a/web-ui/src/app/config.ts
+++ b/web-ui/src/app/config.ts
@@ -5,5 +5,6 @@ export class Config {
 export const addressLabels = {
     '7jqffPwhzkVGbYFf525muhas6uVrhERwAm': 'Cryptopia',
     '7iYWrbBhYczSYPZ3Naesd9Yk4X5qn4dNAg': 'Livecoin',
-    'Xi1BEVHFRYg1QQfrNJF8L9yXvREAADxCLk': 'Stakenet.io Cloud Staking'
+    'Xi1BEVHFRYg1QQfrNJF8L9yXvREAADxCLk': 'Stakenet.io Cloud Staking',
+    'XmPe9BHRsmZeThtYF34YYjdnrjmcAUn8bC': 'Burned coins'
 };


### PR DESCRIPTION
add a tooltip for Total supply and circulating supply

### Problem
It is not explained what Total supply and Circulating supply stand for.

### Solution

added a tooltip for Total supply and circulating supply 
![Screenshot from 2019-06-24 18-41-16](https://user-images.githubusercontent.com/11052423/60060839-cdefd180-96af-11e9-8934-2ca1f0d61c38.png)
![Screenshot from 2019-06-24 18-41-41](https://user-images.githubusercontent.com/11052423/60060840-cfb99500-96af-11e9-9b2a-49ca4b336d11.png)


