### PR TITLE
web-ui: full responsive pages, borderless tables

### DIFF
--- a/web-ui/src/app/components/address-details/address-details.component.html
+++ b/web-ui/src/app/components/address-details/address-details.component.html
@@ -1,83 +1,89 @@
 <div>
-  <div [hidden]="address != null">
-    <alert>{{'message.addressNotFound' | translate}}</alert>
-  </div>
-  <div *ngIf="address != null">
-    <div class="row">
-        <h2 *ngIf="!addressLabel[addressString]" class="col-xs-12">{{'label.address' | translate}}</h2>
-        <h2 *ngIf="addressLabel[addressString]" class="col-xs-12">{{ addressLabel[addressString]}}</h2>
+  <div class="row">
+    <div class="col-xs-12 col-md-offset-2 col-md-8 table-container">
+      <div [hidden]="address != null">
+        <alert>{{'message.addressNotFound' | translate}}</alert>
+      </div>
+      <div *ngIf="address != null">
+        <div class="row">
+          <h2 *ngIf="!addressLabel[addressString]" class="col-xs-12">{{'label.address' | translate}}</h2>
+          <h2 *ngIf="addressLabel[addressString]" class="col-xs-12">{{ addressLabel[addressString]}}</h2>
 
-    </div>
-    <div class="row">
-      <div class="col-xs-12 col-md-4">
+        </div>
+        <div class="row">
+          <div class="col-xs-12">
+            <div class="table-responsive">
+              <table class="table table-condensed table-borderless table-striped table-hover">
+                <thead>
+                  <tr>
+                    <th class="col-xs-2 col-sm-2 col-md-1 col-lg-1">{{'label.summary' | translate}}</th>
+                    <th class="col-xs-2 col-sm-2 col-md-1 col-lg-1"></th>
+                  </tr>
+                </thead>
+
+                <tbody>
+                  <tr>
+                    <td>{{'label.address' | translate}}</td>
+                    <td>{{addressString}}</td>
+                  </tr>
+                  <tr>
+                    <td>{{'label.balance' | translate}}</td>
+                    <td>{{address.available | explorerCurrency}}</td>
+                  </tr>
+                  <tr>
+                    <td>{{'label.received' | translate}}</td>
+                    <td>{{address.received | explorerCurrency}}</td>
+                  </tr>
+                  <tr>
+                    <td>{{'label.spent' | translate}}</td>
+                    <td>{{address.spent | explorerCurrency}}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+
+        <hr>
+
+        <div class="row">
+          <h2 class="col-xs-12">{{'label.transactions' | translate}}</h2>
+        </div>
         <div class="table-responsive">
-          <table class="table table-condensed table-bordered table-striped table-hover">
+          <table class="table table-condensed table-borderless table-striped table-hover">
             <thead>
               <tr>
-                <th class="col-xs-2 col-sm-2 col-md-1 col-lg-1">{{'label.summary' | translate}}</th>
-                <th class="col-xs-2 col-sm-2 col-md-1 col-lg-1"></th>
+                <th class="col-xs-1">#</th>
+                <th class="col-xs-2">{{'label.transaction' | translate}}</th>
+                <th class="col-xs-2">{{'label.blockhash' | translate}}</th>
+                <th class="col-xs-2">{{'label.date' | translate}}</th>
+                <th class="col-xs-3">{{'label.value' | translate}}</th>
+                <th class="col-xs-2">{{'label.size' | translate}}</th>
               </tr>
             </thead>
 
-            <tbody>
-              <tr>
-                <td>{{'label.address' | translate}}</td>
-                <td>{{addressString}}</td>
-              </tr>
-              <tr>
-                <td>{{'label.balance' | translate}}</td>
-                <td>{{address.available | explorerCurrency}}</td>
-              </tr>
-              <tr>
-                <td>{{'label.received' | translate}}</td>
-                <td>{{address.received | explorerCurrency}}</td>
-              </tr>
-              <tr>
-                <td>{{'label.spent' | translate}}</td>
-                <td>{{address.spent | explorerCurrency}}</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+            <tbody
+            infiniteScroll
+            [infiniteScrollDistance]="1"
+            [infiniteScrollThrottle]="300"
+            (scrolled)="load()"
+            [scrollWindow]="true">
+            <tr *ngFor="let index = index; let item of items">
+              <td>{{index + 1}}</td>
+              <td>
+                <a routerLink="/transactions/{{item.id}}">{{item.id | slice:0:15}}...</a>
+              </td>
+              <td>
+                <a routerLink="/blocks/{{item.blockhash}}">{{item.blockhash | slice:0:15}}...</a>
+              </td>
+              <td>{{item.time * 1000 | explorerDatetime}}</td>
+              <td>{{renderValue(item) | explorerCurrency}}</td>
+              <td>{{item.size}} bytes</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
-
-    <div class="row">
-      <h2 class="col-xs-12">{{'label.transactions' | translate}}</h2>
-    </div>
-    <div class="table-responsive">
-      <table class="table table-condensed table-bordered table-striped table-hover">
-        <thead>
-          <tr>
-            <th class="col-xs-1">#</th>
-            <th class="col-xs-2">{{'label.transaction' | translate}}</th>
-            <th class="col-xs-2">{{'label.blockhash' | translate}}</th>
-            <th class="col-xs-2">{{'label.date' | translate}}</th>
-            <th class="col-xs-3">{{'label.value' | translate}}</th>
-            <th class="col-xs-2">{{'label.size' | translate}}</th>
-          </tr>
-        </thead>
-
-        <tbody
-        infiniteScroll
-        [infiniteScrollDistance]="1"
-        [infiniteScrollThrottle]="300"
-        (scrolled)="load()"
-        [scrollWindow]="true">
-          <tr *ngFor="let index = index; let item of items">
-            <td>{{index + 1}}</td>
-            <td>
-              <a routerLink="/transactions/{{item.id}}">{{item.id | slice:0:15}}...</a>
-            </td>
-            <td>
-              <a routerLink="/blocks/{{item.blockhash}}">{{item.blockhash | slice:0:15}}...</a>
-            </td>
-            <td>{{item.time * 1000 | explorerDatetime}}</td>
-            <td>{{renderValue(item) | explorerCurrency}}</td>
-            <td>{{item.size}} bytes</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
   </div>
+</div>
 </div>

--- a/web-ui/src/app/components/block-details/block-details.component.html
+++ b/web-ui/src/app/components/block-details/block-details.component.html
@@ -1,12 +1,15 @@
 <div>
+  
   <div [hidden]="blockDetails != null">
     <alert>{{'message.blockNotFound' | translate}}</alert>
   </div>
+
   <div *ngIf="blockDetails != null">
     <div class="row">
+
       <h2 class="col-xs-12">{{'label.block' | translate}} #{{blockDetails.block.height}}</h2>
 
-      <div class="col-xs-12 col-md-7">
+      <div class="col-xs-12">
         <div class="table-responsive">
           <table class="table table-condensed table-borderless table-striped table-hover">
             <thead>
@@ -72,195 +75,208 @@
                 <td>{{'label.medianTime' | translate}}</td>
                 <td>{{blockDetails.block.medianTime * 1000 | explorerDatetime}}</td>
               </tr>
-              <tr>
-                <td></td>
-                <td></td>
-              </tr>
+            </tbody>
+            
+            <tfoot>
               <tr>
                 <td>
                   <a *ngIf="blockDetails.block.previousBlockhash != null" routerLink="/blocks/{{blockDetails.block.previousBlockhash}}">
                     {{'label.previous' | translate}} ({{blockDetails.block.height - 1}})
                   </a>
                 </td>
-                <td>
+                <td align="right">
                   <a *ngIf="blockDetails.block.nextBlockhash != null" routerLink="/blocks/{{blockDetails.block.nextBlockhash}}">
                     {{'label.next' | translate}} ({{blockDetails.block.height + 1}})
                   </a>
                 </td>
               </tr>
-            </tbody>
+            </tfoot>
           </table>
         </div>
       </div>
 
+      <hr>
+
       <!-- rewards -->
-      <div class="col-xs-12 col-md-offset-1 col-md-4" *ngIf="blockDetails.rewards != null">
-        <div class="table-responsive">
+      <div class="col-xs-12" *ngIf="blockDetails.rewards != null">
+          
           <!-- PoW -->
           <div *ngIf="isPoW(blockDetails)">
-            <table class="table table-condensed table-bordered table-striped table-hover">
-              <thead>
-                <tr>
-                  <th class="col-xs-2 col-md-1">{{'label.blockReward' | translate}}</th>
-                  <th class="col-xs-2 col-md-1">{{blockDetails.rewards.reward.value | explorerCurrency}}</th>
-                </tr>
-              </thead>
+            <hr>
+            <div class="table-responsive">
+              <table class="table table-condensed table-borderless table-striped table-hover">
+                <thead>
+                  <tr>
+                    <th class="col-xs-2 col-md-1">{{'label.blockReward' | translate}}</th>
+                    <th class="col-xs-2 col-md-1">{{blockDetails.rewards.reward.value | explorerCurrency}}</th>
+                  </tr>
+                </thead>
 
-              <tbody>
-                <tr>
-                  <td>{{'label.address' | translate}}</td>
-                  <td>
-                    <a routerLink="/addresses/{{blockDetails.rewards.reward.address}}">{{blockDetails.rewards.reward.address}}</a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                <tbody>
+                  <tr>
+                    <td>{{'label.address' | translate}}</td>
+                    <td>
+                      <a routerLink="/addresses/{{blockDetails.rewards.reward.address}}">{{blockDetails.rewards.reward.address}}</a>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
 
           <!-- PoS -->
           <div *ngIf="isPoS(blockDetails)">
-            <table class="table table-condensed table-bordered table-striped table-hover">
-              <thead>
-                <tr>
-                  <th class="col-xs-2 col-md-1">{{'label.rewards' | translate}}</th>
-                  <th class="col-xs-2 col-md-1">{{getPoSTotalReward(blockDetails) | explorerCurrency}}</th>
-                </tr>
-              </thead>
+            <hr>
+            <div class="table-responsive">
+              <table class="table table-condensed table-borderless table-striped table-hover">
+                <thead>
+                  <tr>
+                    <th class="col-xs-2 col-md-1">{{'label.rewards' | translate}}</th>
+                    <th class="col-xs-2 col-md-1">{{getPoSTotalReward(blockDetails) | explorerCurrency}}</th>
+                  </tr>
+                </thead>
 
-              <tbody>
-                <tr>
-                  <td></td>
-                  <td></td>
-                </tr>
-                <tr>
-                  <td>
-                    <strong>{{'label.coinstake' | translate}}</strong>
-                  </td>
-                  <td></td>
-                </tr>
-                <tr>
-                  <td>{{'label.amount' | translate}}</td>
-                  <td>{{blockDetails.rewards.coinstake.value | explorerCurrency}}</td>
-                </tr>
-                <tr>
-                  <td>{{'label.address' | translate}}</td>
-                  <td>
-                    <a routerLink="/addresses/{{blockDetails.rewards.coinstake.address}}">{{blockDetails.rewards.coinstake.address}}</a>
-                  </td>
-                </tr>
-                <tr>
-                  <td></td>
-                  <td></td>
-                </tr>
-                <tr *ngIf="blockDetails.rewards.masternode != null">
-                  <td>
-                    <strong>{{'label.masternode' | translate}}</strong>
-                  </td>
-                  <td></td>
-                </tr>
-                <tr *ngIf="blockDetails.rewards.masternode != null">
-                  <td>{{'label.amount' | translate}}</td>
-                  <td>{{blockDetails.rewards.masternode.value | explorerCurrency}}</td>
-                </tr>
-                <tr *ngIf="blockDetails.rewards.masternode != null">
-                  <td>{{'label.address' | translate}}</td>
-                  <td>
-                    <a routerLink="/addresses/{{blockDetails.rewards.masternode.address}}">{{blockDetails.rewards.masternode.address}}</a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                <tbody>
+                  <tr>
+                    <td></td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <strong>{{'label.coinstake' | translate}}</strong>
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>{{'label.amount' | translate}}</td>
+                    <td>{{blockDetails.rewards.coinstake.value | explorerCurrency}}</td>
+                  </tr>
+                  <tr>
+                    <td>{{'label.address' | translate}}</td>
+                    <td>
+                      <a routerLink="/addresses/{{blockDetails.rewards.coinstake.address}}">{{blockDetails.rewards.coinstake.address}}</a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td></td>
+                    <td></td>
+                  </tr>
+                  <tr *ngIf="blockDetails.rewards.masternode != null">
+                    <td>
+                      <strong>{{'label.masternode' | translate}}</strong>
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr *ngIf="blockDetails.rewards.masternode != null">
+                    <td>{{'label.amount' | translate}}</td>
+                    <td>{{blockDetails.rewards.masternode.value | explorerCurrency}}</td>
+                  </tr>
+                  <tr *ngIf="blockDetails.rewards.masternode != null">
+                    <td>{{'label.address' | translate}}</td>
+                    <td>
+                      <a routerLink="/addresses/{{blockDetails.rewards.masternode.address}}">{{blockDetails.rewards.masternode.address}}</a>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
 
           <!-- TPoS -->
           <div *ngIf="isTPoS(blockDetails)">
-            <table class="table table-condensed table-bordered table-striped table-hover">
-              <thead>
-                <tr>
-                  <th class="col-xs-2 col-md-1">{{'label.rewards' | translate}}</th>
-                  <th class="col-xs-2 col-md-1">{{getTPoSTotalReward(blockDetails) | explorerCurrency}}</th>
-                </tr>
-              </thead>
+            <hr>
+            <div class="table-responsive">
+              <table class="table table-condensed table-borderless table-striped table-hover">
+                <thead>
+                  <tr>
+                    <th class="col-xs-2 col-md-1">{{'label.rewards' | translate}}</th>
+                    <th class="col-xs-2 col-md-1">{{getTPoSTotalReward(blockDetails) | explorerCurrency}}</th>
+                  </tr>
+                </thead>
 
-              <tbody>
-                <tr>
-                  <td></td>
-                  <td></td>
-                </tr>
-                <tr>
-                  <td>
-                    <strong>{{'label.owner' | translate}}</strong>
-                  </td>
-                  <td></td>
-                </tr>
-                <tr>
-                  <td>{{'label.amount' | translate}}</td>
-                  <td>{{blockDetails.rewards.owner.value | explorerCurrency}}</td>
-                </tr>
-                <tr>
-                  <td>{{'label.address' | translate}}</td>
-                  <td>
-                    <a routerLink="/addresses/{{blockDetails.rewards.owner.address}}">{{blockDetails.rewards.owner.address}}</a>
-                  </td>
-                </tr>
+                <tbody>
+                  <tr>
+                    <td></td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <strong>{{'label.owner' | translate}}</strong>
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>{{'label.amount' | translate}}</td>
+                    <td>{{blockDetails.rewards.owner.value | explorerCurrency}}</td>
+                  </tr>
+                  <tr>
+                    <td>{{'label.address' | translate}}</td>
+                    <td>
+                      <a routerLink="/addresses/{{blockDetails.rewards.owner.address}}">{{blockDetails.rewards.owner.address}}</a>
+                    </td>
+                  </tr>
 
-                <tr>
-                  <td></td>
-                  <td></td>
-                </tr>
-                <tr>
-                  <td>
-                    <strong>{{'label.merchant' | translate}}</strong>
-                  </td>
-                  <td></td>
-                </tr>
-                <tr>
-                  <td>{{'label.amount' | translate}}</td>
-                  <td>{{blockDetails.rewards.merchant.value | explorerCurrency}}</td>
-                </tr>
-                <tr>
-                  <td>{{'label.address' | translate}}</td>
-                  <td>
-                    <a routerLink="/addresses/{{blockDetails.rewards.merchant.address}}">{{blockDetails.rewards.merchant.address}}</a>
-                  </td>
-                </tr>
+                  <tr>
+                    <td></td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>
+                      <strong>{{'label.merchant' | translate}}</strong>
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr>
+                    <td>{{'label.amount' | translate}}</td>
+                    <td>{{blockDetails.rewards.merchant.value | explorerCurrency}}</td>
+                  </tr>
+                  <tr>
+                    <td>{{'label.address' | translate}}</td>
+                    <td>
+                      <a routerLink="/addresses/{{blockDetails.rewards.merchant.address}}">{{blockDetails.rewards.merchant.address}}</a>
+                    </td>
+                  </tr>
 
-                <tr>
-                  <td></td>
-                  <td></td>
-                </tr>
-                <tr *ngIf="blockDetails.rewards.masternode != null">
-                  <td>
-                    <strong>{{'label.masternode' | translate}}</strong>
-                  </td>
-                  <td></td>
-                </tr>
-                <tr *ngIf="blockDetails.rewards.masternode != null">
-                  <td>{{'label.amount' | translate}}</td>
-                  <td>{{blockDetails.rewards.masternode.value | explorerCurrency}}</td>
-                </tr>
-                <tr *ngIf="blockDetails.rewards.masternode != null">
-                  <td>{{'label.address' | translate}}</td>
-                  <td>
-                    <a routerLink="/addresses/{{blockDetails.rewards.masternode.address}}">{{blockDetails.rewards.masternode.address}}</a>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+                  <tr>
+                    <td></td>
+                    <td></td>
+                  </tr>
+                  <tr *ngIf="blockDetails.rewards.masternode != null">
+                    <td>
+                      <strong>{{'label.masternode' | translate}}</strong>
+                    </td>
+                    <td></td>
+                  </tr>
+                  <tr *ngIf="blockDetails.rewards.masternode != null">
+                    <td>{{'label.amount' | translate}}</td>
+                    <td>{{blockDetails.rewards.masternode.value | explorerCurrency}}</td>
+                  </tr>
+                  <tr *ngIf="blockDetails.rewards.masternode != null">
+                    <td>{{'label.address' | translate}}</td>
+                    <td>
+                      <a routerLink="/addresses/{{blockDetails.rewards.masternode.address}}">{{blockDetails.rewards.masternode.address}}</a>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </div>
-        </div>
+
       </div>
 
       <!-- transactions -->
       <!-- still no transactions -->
-      <div *ngIf="transactions == null" class="col-xs-12 col-md-offset-2 col-md-8">
+      <div *ngIf="transactions == null" class="col-xs-12">
         <alert>{{'message.transactionsNotAvailable' | translate}}</alert>
       </div>
 
       <!-- paginated transactions -->
-      <div *ngIf="transactions != null && transactions.length != 0" class="col-xs-12 col-md-offset-2 col-md-8">
+      <div *ngIf="transactions != null && transactions.length != 0" class="col-xs-12">
+        
+        <hr>
+
         <div class="table-responsive">
-          <table class="table table-condensed table-bordered table-striped table-hover">
+          <table class="table table-condensed table-borderless table-striped table-hover">
             <thead>
               <tr>
                 <th class="col-xs-1">#</th>
@@ -277,23 +293,26 @@
             [infiniteScrollThrottle]="300"
             (scrolled)="load()"
             [scrollWindow]="true">
-              <tr *ngFor="let index = index; let item of transactions">
-                <td>{{index + 1}}</td>
-                <td>
-                  <a routerLink="/transactions/{{item.id}}">{{item.id | slice:0:35}}...</a>
-                </td>
-                <td>{{item.time * 1000 | explorerDatetime}}</td>
-                <td>{{item.sent | explorerCurrency}}</td>
-                <td>{{item.size}} bytes</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
+            <tr *ngFor="let index = index; let item of transactions">
+              <td>{{index + 1}}</td>
+              <td>
+                <a routerLink="/transactions/{{item.id}}">{{item.id | slice:0:35}}...</a>
+              </td>
+              <td>{{item.time * 1000 | explorerDatetime}}</td>
+              <td>{{item.sent | explorerCurrency}}</td>
+              <td>{{item.size}} bytes</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
 
       <!-- transaction list only -->
-      <div *ngIf="transactions != null && transactions.length == 0" class="col-xs-12 col-md-offset-2 col-md-8">
+      <div *ngIf="transactions != null && transactions.length == 0" class="col-xs-12">
+        
+        <hr>
+
         <div class="table-responsive">
-          <table class="table table-condensed table-bordered table-striped table-hover">
+          <table class="table table-condensed table-borderless table-striped table-hover">
             <thead>
               <tr>
                 <th class="col-xs-1">#</th>
@@ -311,7 +330,10 @@
             </tbody>
           </table>
         </div>
+
       </div>
+
     </div>
+
   </div>
 </div>

--- a/web-ui/src/app/components/block/block.component.html
+++ b/web-ui/src/app/components/block/block.component.html
@@ -1,10 +1,14 @@
 <div>
-  <tabset class="col-xs-12 col-sm-12 col-md-12 col-xs-12">
-    <tab heading="{{'label.details' | translate}}" (select)="selectView('details')">
-      <app-block-details *ngIf="isSelected('details')"></app-block-details>
-    </tab>
-    <tab heading="{{'label.raw' | translate}}" (select)="selectView('raw')">
-      <app-block-raw *ngIf="isSelected('raw')"></app-block-raw>
-    </tab>
-  </tabset>
+  <div class="row">
+    <div class="col-xs-12 col-md-offset-2 col-md-8 table-container">
+      	<tabset class="col-xs-12">
+		    <tab heading="{{'label.details' | translate}}" (select)="selectView('details')">
+		      <app-block-details *ngIf="isSelected('details')"></app-block-details>
+		    </tab>
+		    <tab heading="{{'label.raw' | translate}}" (select)="selectView('raw')">
+		      <app-block-raw *ngIf="isSelected('raw')"></app-block-raw>
+		    </tab>
+		</tabset>
+    </div>
+  </div>
 </div>

--- a/web-ui/src/app/components/latest-blocks/latest-blocks.component.css
+++ b/web-ui/src/app/components/latest-blocks/latest-blocks.component.css
@@ -7,12 +7,3 @@
     background-color: #D4FFD4;
   }
 }
-
-.table-borderless > tbody > tr > td,
-.table-borderless > tbody > tr > th,
-.table-borderless > tfoot > tr > td,
-.table-borderless > tfoot > tr > th,
-.table-borderless > thead > tr > td,
-.table-borderless > thead > tr > th {
-    border: none;
-}

--- a/web-ui/src/app/components/masternode-details/masternode-details.component.html
+++ b/web-ui/src/app/components/masternode-details/masternode-details.component.html
@@ -1,39 +1,49 @@
 <div>
-  <div [hidden]="masternode != null">
-    <alert>{{'message.masternodeNotFound' | translate}}</alert>
-  </div>
-  <div *ngIf="masternode != null">
-    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
-      <table class="table table-condensed table-bordered table-striped table-hover">
-        <tbody>
-          <tr>
-            <td>{{'label.address' | translate}}</td>
-            <td>{{masternode.ip}}</td>
-          </tr>
-          <tr>
-            <td>{{'label.active' | translate}}</td>
-            <td>{{Math.max(masternode.activeSeconds, 0) | amDuration:'seconds'}}</td>
-          </tr>
-          <tr>
-            <td>{{'label.lastSeen' | translate}}</td>
-            <td>{{masternode.lastSeen * 1000 | explorerDatetime}}</td>
-          </tr>
-          <!-- TODO: Display status when the WATCHDOG_EXPIRED bug is fixed.
-          <tr>
-            <td>{{'label.status' | translate}}</td>
-            <td>{{masternode.status}}</td>
-          </tr>
-          -->
-          <tr>
-            <td>{{'label.address' | translate}}</td>
-            <td><a routerLink="/addresses/{{masternode.payee}}">{{masternode.payee}}</a></td>
-          </tr>
-          <tr>
-            <td>{{'label.protocol' | translate}}</td>
-            <td>{{masternode.protocol}}</td>
-          </tr>
-        </tbody>
-      </table>
+  <div class="row">
+    <div class="col-xs-12 col-md-offset-2 col-md-8 table-container">
+
+      <br>
+
+      <div [hidden]="masternode != null">
+        <alert>{{'message.masternodeNotFound' | translate}}</alert>
+      </div>
+
+      <div *ngIf="masternode != null">
+          <div class="table-responsive">
+            <table class="table table-condensed table-borderless table-striped table-hover">
+              <tbody>
+                <tr>
+                  <td>{{'label.address' | translate}}</td>
+                  <td>{{masternode.ip}}</td>
+                </tr>
+                <tr>
+                  <td>{{'label.active' | translate}}</td>
+                  <td>{{Math.max(masternode.activeSeconds, 0) | amDuration:'seconds'}}</td>
+                </tr>
+                <tr>
+                  <td>{{'label.lastSeen' | translate}}</td>
+                  <td>{{masternode.lastSeen * 1000 | explorerDatetime}}</td>
+                </tr>
+                <!-- TODO: Display status when the WATCHDOG_EXPIRED bug is fixed.
+                  <tr>
+                  <td>{{'label.status' | translate}}</td>
+                  <td>{{masternode.status}}</td>
+                  </tr>
+                -->
+                <tr>
+                  <td>{{'label.address' | translate}}</td>
+                  <td><a routerLink="/addresses/{{masternode.payee}}">{{masternode.payee}}</a></td>
+                </tr>
+                <tr>
+                  <td>{{'label.protocol' | translate}}</td>
+                  <td>{{masternode.protocol}}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+      </div>
+
+
     </div>
   </div>
 </div>

--- a/web-ui/src/app/components/masternodes/masternodes.component.css
+++ b/web-ui/src/app/components/masternodes/masternodes.component.css
@@ -1,8 +1,0 @@
-.table-borderless > tbody > tr > td,
-.table-borderless > tbody > tr > th,
-.table-borderless > tfoot > tr > td,
-.table-borderless > tfoot > tr > th,
-.table-borderless > thead > tr > td,
-.table-borderless > thead > tr > th {
-    border: none;
-}

--- a/web-ui/src/app/components/richest-addresses/richest-addresses.component.css
+++ b/web-ui/src/app/components/richest-addresses/richest-addresses.component.css
@@ -7,12 +7,3 @@
     background-color: #D4FFD4;
   }
 }
-
-.table-borderless > tbody > tr > td,
-.table-borderless > tbody > tr > th,
-.table-borderless > tfoot > tr > td,
-.table-borderless > tfoot > tr > th,
-.table-borderless > thead > tr > td,
-.table-borderless > thead > tr > th {
-    border: none;
-}

--- a/web-ui/src/app/components/transaction-details/transaction-details.component.html
+++ b/web-ui/src/app/components/transaction-details/transaction-details.component.html
@@ -4,96 +4,102 @@
   </div>
   <div *ngIf="transaction != null">
     <div class="row">
-      <div class="col-xs-12 col-sm-12 col-md-4 col-lg-4">
-        <table class="table table-condensed table-bordered table-striped table-hover">
-          <thead>
-            <tr>
-              <th class="col-xs-3 col-sm-3 col-md-2 col-lg-2">{{'label.summary' | translate}}</th>
-              <th class="col-xs-5 col-sm-5 col-md-4 col-lg-4"></th>
-            </tr>
-          </thead>
+      <div class="col-xs-12">
+        <div class="table-responsive">
+          <table class="table table-condensed table-borderless table-striped table-hover">
+            <thead>
+              <tr>
+                <th>{{'label.summary' | translate}}</th>
+                <th></th>
+              </tr>
+            </thead>
 
-          <tbody>
-            <tr>
-              <td>{{'label.transactionId' | translate}}</td>
-              <td>{{transaction.id}}</td>
-            </tr>
-            <tr>
-              <td>{{'label.confirmations' | translate}}</td>
-              <td>{{transaction.confirmations}}</td>
-            </tr>
-            <tr>
-              <td>{{'label.blockhash' | translate}}</td>
-              <td>
-                <a routerLink="/blocks/{{transaction.blockhash}}">{{transaction.blockhash}}</a>
-              </td>
-            </tr>
-            <tr>
-              <td>{{'label.blocktime' | translate}}</td>
-              <td>{{transaction.blocktime * 1000 | explorerDatetime}}</td>
-            </tr>
-            <tr>
-              <td>{{'label.fee' | translate}}</td>
-              <td>{{getFee(transaction) | explorerCurrency}}</td>
-            </tr>
-          </tbody>
-        </table>
+            <tbody>
+              <tr>
+                <td>{{'label.transactionId' | translate}}</td>
+                <td>{{transaction.id}}</td>
+              </tr>
+              <tr>
+                <td>{{'label.confirmations' | translate}}</td>
+                <td>{{transaction.confirmations}}</td>
+              </tr>
+              <tr>
+                <td>{{'label.blockhash' | translate}}</td>
+                <td>
+                  <a routerLink="/blocks/{{transaction.blockhash}}">{{transaction.blockhash}}</a>
+                </td>
+              </tr>
+              <tr>
+                <td>{{'label.blocktime' | translate}}</td>
+                <td>{{transaction.blocktime * 1000 | explorerDatetime}}</td>
+              </tr>
+              <tr>
+                <td>{{'label.fee' | translate}}</td>
+                <td>{{getFee(transaction) | explorerCurrency}}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
 
+    <hr>
+
     <div class="row">
       <!-- Input -->
-      <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5">
-        <table class="table table-condensed table-bordered table-striped table-hover">
-          <thead>
-            <tr *ngIf="transaction.input == null || transaction.input.length == 0">
-              <th class="col-xs-4 col-sm-4 col-md-3 col-lg-3">{{'label.noInput' | translate}}</th>
-              <th class="col-xs-5 col-sm-5 col-md-4 col-lg-4"></th>
-            </tr>
-            <tr *ngIf="transaction.input != null && transaction.input.length != 0">
-              <th class="col-xs-4 col-sm-4 col-md-3 col-lg-3">{{'label.from' | translate}}</th>
-              <th class="col-xs-5 col-sm-5 col-md-4 col-lg-4">{{ getTotal(collapsedInput) | explorerCurrency }}</th>
-            </tr>
-          </thead>
+      <div class="col-xs-12">
+        <div class="table-responsive">
+          <table class="table table-condensed table-borderless table-striped table-hover">
+            <thead>
+              <tr *ngIf="transaction.input == null || transaction.input.length == 0">
+                <th class="col-xs-4 col-sm-4 col-md-3 col-lg-3">{{'label.noInput' | translate}}</th>
+                <th class="col-xs-5 col-sm-5 col-md-4 col-lg-4"></th>
+              </tr>
+              <tr *ngIf="transaction.input != null && transaction.input.length != 0">
+                <th class="col-xs-4 col-sm-4 col-md-3 col-lg-3">{{'label.from' | translate}}</th>
+                <th class="col-xs-5 col-sm-5 col-md-4 col-lg-4">{{ getTotal(collapsedInput) | explorerCurrency }}</th>
+              </tr>
+            </thead>
 
-          <tbody>
-            <tr *ngIf="transaction.input == null || transaction.input.length == 0">
-              <td>{{'label.coinbase' | translate}}</td>
-              <td></td>
-            </tr>
-            <tr *ngFor="let item of collapsedInput">
-              <td *ngIf="count(item.address, transaction.input) != 1">
-                <a routerLink="/addresses/{{item.address}}">{{item.address}}</a> ({{count(item.address, transaction.input)}})
-              </td>
-              <td *ngIf="count(item.address, transaction.input) == 1">
-                <a routerLink="/addresses/{{item.address}}">{{item.address}}</a>
-              </td>
-              <td>{{item.value | explorerCurrency}}</td>
-            </tr>
-            <tr>
-              <td></td>
-              <td></td>
-            </tr>
+            <tbody>
+              <tr *ngIf="transaction.input == null || transaction.input.length == 0">
+                <td>{{'label.coinbase' | translate}}</td>
+                <td></td>
+              </tr>
+              <tr *ngFor="let item of collapsedInput">
+                <td *ngIf="count(item.address, transaction.input) != 1">
+                  <a routerLink="/addresses/{{item.address}}">{{item.address}}</a> ({{count(item.address, transaction.input)}})
+                </td>
+                <td *ngIf="count(item.address, transaction.input) == 1">
+                  <a routerLink="/addresses/{{item.address}}">{{item.address}}</a>
+                </td>
+                <td>{{item.value | explorerCurrency}}</td>
+              </tr>
+              <tr>
+                <td></td>
+                <td></td>
+              </tr>
 
-            <!-- Output -->
-            <tr>
-              <td><strong>{{'label.output' | translate}}</strong></td>
-              <td *ngIf="transaction.output == null || transaction.output.length == 0"></td>
-              <th *ngIf="transaction.output != null && transaction.output.length != 0">
-                  {{ getTotal(collapsedOutput) | explorerCurrency }}
-              </th>
-            </tr>
-            <tr *ngFor="let item of collapsedOutput">
-              <td *ngIf="count(item.address, transaction.output) != 1">
-                <a routerLink="/addresses/{{item.address}}">{{item.address}}</a> ({{count(item.address, transaction.output)}})
-              </td>
-              <td *ngIf="count(item.address, transaction.output) == 1">
-                <a routerLink="/addresses/{{item.address}}">{{item.address}}</a>
-              </td>
-              <td>{{item.value | explorerCurrency}}</td>
-            </tr>
-          </tbody>
-        </table>
+              <!-- Output -->
+              <tr>
+                <td><strong>{{'label.output' | translate}}</strong></td>
+                <td *ngIf="transaction.output == null || transaction.output.length == 0"></td>
+                <th *ngIf="transaction.output != null && transaction.output.length != 0">
+                    {{ getTotal(collapsedOutput) | explorerCurrency }}
+                </th>
+              </tr>
+              <tr *ngFor="let item of collapsedOutput">
+                <td *ngIf="count(item.address, transaction.output) != 1">
+                  <a routerLink="/addresses/{{item.address}}">{{item.address}}</a> ({{count(item.address, transaction.output)}})
+                </td>
+                <td *ngIf="count(item.address, transaction.output) == 1">
+                  <a routerLink="/addresses/{{item.address}}">{{item.address}}</a>
+                </td>
+                <td>{{item.value | explorerCurrency}}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   </div>

--- a/web-ui/src/app/components/transaction/transaction.component.html
+++ b/web-ui/src/app/components/transaction/transaction.component.html
@@ -1,13 +1,17 @@
 <div>
   <div class="row">
-    <h2 class="col-xs-12 col-sm-12 col-md-12 col-lg-12">{{'label.transaction' | translate}}</h2>
+    <div class="col-xs-12 col-md-offset-2 col-md-8 table-container">
+        <div class="row">
+          <h2 class="col-xs-12">{{'label.transaction' | translate}}</h2>
+          <tabset class="col-xs-12">
+            <tab heading="{{'label.details' | translate}}" (select)="selectView('details')">
+              <app-transaction-details *ngIf="isSelected('details')"></app-transaction-details>
+            </tab>
+            <tab heading="{{'label.raw' | translate}}" (select)="selectView('raw')">
+              <app-transaction-raw *ngIf="isSelected('raw')"></app-transaction-raw>
+            </tab>
+          </tabset>
+        </div>
+    </div>
   </div>
-  <tabset class="col-xs-12 col-sm-12 col-md-12 col-xs-12">
-    <tab heading="{{'label.details' | translate}}" (select)="selectView('details')">
-      <app-transaction-details *ngIf="isSelected('details')"></app-transaction-details>
-    </tab>
-    <tab heading="{{'label.raw' | translate}}" (select)="selectView('raw')">
-      <app-transaction-raw *ngIf="isSelected('raw')"></app-transaction-raw>
-    </tab>
-  </tabset>
 </div>

--- a/web-ui/src/styles.css
+++ b/web-ui/src/styles.css
@@ -15,3 +15,20 @@ body {
    background: linear-gradient( #141829 60%, #f8f8f8 40%);
    background-attachment:fixed;
 }
+
+.table-borderless > tbody > tr > td,
+.table-borderless > tbody > tr > th,
+.table-borderless > tfoot > tr > td,
+.table-borderless > tfoot > tr > th,
+.table-borderless > thead > tr > td,
+.table-borderless > thead > tr > th {
+    border: none;
+}
+
+.table-container {
+    background-color: white;
+    border-radius: 4px;
+    -webkit-box-shadow: 0px 0px 5px 0px rgba(0,0,0,0.75);
+    -moz-box-shadow: 0px 0px 5px 0px rgba(0,0,0,0.75);
+    box-shadow: 0px 0px 5px 0px rgba(0,0,0,0.75);
+}


### PR DESCRIPTION
### Problem

Missing the design corresponding to the following views: blocks, addresses, transactions.

### Solution

Design similar to the home page is applied.

### Result

All pages can be opened from any screen sizes because it is now full responsive.

Screenshots included.
Blocks:
<img width="1280" alt="Screen Shot 2019-08-21 at 1 29 38 PM" src="https://user-images.githubusercontent.com/10841708/63458546-99329900-c418-11e9-9571-320a1ae2e74d.png">

![localhost_4200_blocks_38d60b09dea3142737006069b7d4188fbcc232f2b2a8ad0e172b4ed7ac36e6af(iPhone 6_7_8)](https://user-images.githubusercontent.com/10841708/63458594-ae0f2c80-c418-11e9-9467-a962b34f0757.png)


Transactions:
<img width="1280" alt="Screen Shot 2019-08-21 at 1 34 27 PM" src="https://user-images.githubusercontent.com/10841708/63458616-bbc4b200-c418-11e9-813e-630bb7513d6e.png">

![localhost_4200_transactions_cfb029390a647aa20cb8a29c845a332674660d816b32bc8456c1e19b86a111d0(iPhone 6_7_8)](https://user-images.githubusercontent.com/10841708/63458643-c7b07400-c418-11e9-9557-74a7598c8f97.png)


Addresses:
<img width="1280" alt="Screen Shot 2019-08-21 at 1 38 28 PM" src="https://user-images.githubusercontent.com/10841708/63458759-fcbcc680-c418-11e9-8b04-65117ebd9599.png">

![localhost_4200_addresses_Xi1BEVHFRYg1QQfrNJF8L9yXvREAADxCLk(iPhone 6_7_8)](https://user-images.githubusercontent.com/10841708/63458801-11995a00-c419-11e9-90f4-785b442e0bb9.png)


Masternodes:
<img width="1280" alt="Screen Shot 2019-08-19 at 4 42 43 PM" src="https://user-images.githubusercontent.com/10841708/63301843-35399480-c2a1-11e9-8119-41ec793d562d.png">

![localhost_4200_masternodes_45 76 62 195(iPhone 6_7_8)](https://user-images.githubusercontent.com/10841708/63301849-3cf93900-c2a1-11e9-9a5d-faf2405d3379.png)




