### PR TITLE
server: Add GET /transactions/:txid/lite endpoint, included unit tests

### DIFF
--- a/server/app/controllers/TransactionsController.scala
+++ b/server/app/controllers/TransactionsController.scala
@@ -21,4 +21,8 @@ class TransactionsController @Inject()(transactionRPCService: TransactionRPCServ
   def sendRawTransaction() = publicInput { ctx: HasModel[SendRawTransactionRequest] =>
     transactionRPCService.sendRawTransaction(ctx.model.hex)
   }
+
+  def getTransactionLite(txid: String) = public { _ =>
+    transactionRPCService.getTransactionLite(txid)
+  }
 }

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -9,6 +9,7 @@ GET   /health                controllers.HealthController.check()
 GET   /transactions/:txid        controllers.TransactionsController.getTransaction(txid: String)
 GET   /transactions/:txid/raw    controllers.TransactionsController.getRawTransaction(txid: String)
 POST  /transactions              controllers.TransactionsController.sendRawTransaction()
+GET   /transactions/:txid/lite   controllers.TransactionsController.getTransactionLite(txid: String)
 
 GET   /addresses/:address                            controllers.AddressesController.getBy(address: String)
 GET   /addresses/:address/tposcontracts              controllers.AddressesController.getTPoSContracts(address: String)

--- a/server/test/com/xsn/explorer/helpers/FileBasedXSNService.scala
+++ b/server/test/com/xsn/explorer/helpers/FileBasedXSNService.scala
@@ -8,6 +8,7 @@ import org.scalactic.{Good, One, Or}
 import play.api.libs.json.JsValue
 
 import scala.concurrent.Future
+import scala.util.Try
 
 class FileBasedXSNService extends DummyXSNService {
 
@@ -62,7 +63,8 @@ class FileBasedXSNService extends DummyXSNService {
   }
 
   override def getRawTransaction(txid: TransactionId): FutureApplicationResult[JsValue] = {
-    val tx = TransactionLoader.json(txid.string)
-    Future.successful(Good(tx))
+    val maybe = Try(TransactionLoader.json(txid.string)).toOption
+    val result = Or.from(maybe, One(TransactionError.NotFound(txid)))
+    Future.successful(result)
   }
 }


### PR DESCRIPTION
### Problem

It needs an endpoint to get a transaction lite, required for light wallet

### Solution

Add a new endpoint to get transactions lite and include unit tests

### Result

Added `GET /transactions/:txid/lite` endpoint and corresponding unit test in `TransactionsControllerSpec` file