### PR TITLE
server: Add GET /blocks/:blockhash/lite endpoint

### DIFF
--- a/server/app/controllers/BlocksController.scala
+++ b/server/app/controllers/BlocksController.scala
@@ -1,8 +1,7 @@
 package controllers
 
 import com.alexitc.playsonify.core.FutureOr.Implicits.FutureOps
-import com.alexitc.playsonify.models.ordering.OrderingQuery
-import com.alexitc.playsonify.models.pagination.{Limit, Offset, PaginatedQuery}
+import com.alexitc.playsonify.models.pagination.Limit
 import com.xsn.explorer.models.LightWalletTransaction
 import com.xsn.explorer.models.persisted.BlockHeader
 import com.xsn.explorer.models.values.Height
@@ -94,6 +93,23 @@ class BlocksController @Inject()(
 
   def estimateFee(nBlocks: Int) = public { _ =>
     blockService.estimateFee(nBlocks)
+  }
+
+  def getBlockLite(blockhash: String) = public { _ =>
+    blockService
+      .getBlockLite(blockhash)
+      .toFutureOr
+      .map {
+        case (value, cacheable) => {
+          val response = Ok(Json.toJson(value))
+          if (cacheable) {
+            response.withHeaders("Cache-Control" -> "public, max-age=31536000")
+          } else {
+            response.withHeaders("Cache-Control" -> "no-store")
+          }
+        }
+      }
+      .toFuture
   }
 }
 

--- a/server/conf/routes
+++ b/server/conf/routes
@@ -21,6 +21,7 @@ GET   /blocks                            controllers.BlocksController.getLatestB
 GET   /block-headers                     controllers.BlocksController.getBlockHeaders(lastSeenHash: Option[String], limit: Int ?= 10, order: String ?= "asc")
 GET   /block-headers/:query              controllers.BlocksController.getBlockHeader(query: String, includeFilter: Boolean ?= false)
 GET   /blocks/estimate-fee               controllers.BlocksController.estimateFee(nBlocks: Int ?= 1)
+GET   /blocks/:blockhash/lite            controllers.BlocksController.getBlockLite(blockhash: String)
 
 GET   /blocks/:query                     controllers.BlocksController.getDetails(query: String)
 GET   /blocks/:query/raw                 controllers.BlocksController.getRawBlock(query: String)

--- a/server/test/com/xsn/explorer/helpers/DummyXSNService.scala
+++ b/server/test/com/xsn/explorer/helpers/DummyXSNService.scala
@@ -29,4 +29,5 @@ class DummyXSNService extends XSNService {
   override def estimateSmartFee(confirmationsTarget: Int): FutureApplicationResult[JsValue] = ???
   override def getTxOut(txid: TransactionId, index: Int, includeMempool: Boolean): FutureApplicationResult[JsValue] =
     ???
+  override def getFullRawBlock(blockhash: Blockhash): FutureApplicationResult[JsValue] = ???
 }


### PR DESCRIPTION
### Problem

It needs an endpoint to retrieve the header and hex transactions from a given blockhash

### Solution

Add a new endpoint that meets the mentioned requirement

### Result

Now there is an endpoint `GET /blocks/:blockhash/lite` for mentioned requirement