### PR TITLE
server: Add cache to all endpoints

### DIFF
--- a/server/app/controllers/AddressesController.scala
+++ b/server/app/controllers/AddressesController.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import com.alexitc.playsonify.core.FutureOr.Implicits.FutureOps
 import com.alexitc.playsonify.models.ordering.OrderingQuery
 import com.alexitc.playsonify.models.pagination.{Limit, Offset, PaginatedQuery}
 import com.xsn.explorer.models.LightWalletTransaction
@@ -22,11 +23,25 @@ class AddressesController @Inject()(
 
   def getBy(address: String) = public { _ =>
     addressService.getBy(address)
+    .toFutureOr
+    .map {
+      value =>
+        val response = Ok(Json.toJson(value))
+        response.withHeaders("Cache-Control" -> "public, max-age=60")
+    }
+    .toFuture
   }
 
   def getLightWalletTransactions(address: String, limit: Int, lastSeenTxid: Option[String], orderingCondition: String) =
     public { _ =>
       transactionService.getLightWalletTransactions(address, Limit(limit), lastSeenTxid, orderingCondition)
+      .toFutureOr
+      .map {
+        value =>
+          val response = Ok(Json.toJson(value))
+          response.withHeaders("Cache-Control" -> "public, max-age=60")
+      }
+      .toFuture
     }
 
   /**
@@ -52,10 +67,24 @@ class AddressesController @Inject()(
 
   def getUnspentOutputs(address: String) = public { _ =>
     addressService.getUnspentOutputs(address)
+    .toFutureOr
+    .map {
+      value =>
+        val response = Ok(Json.toJson(value))
+        response.withHeaders("Cache-Control" -> "public, max-age=60")
+    }
+    .toFuture
   }
 
   def getTPoSContracts(address: String) = public { _ =>
     tposContractService.getBy(address)
+    .toFutureOr
+    .map {
+      value =>
+        val response = Ok(Json.toJson(value))
+        response.withHeaders("Cache-Control" -> "public, max-age=60")
+    }
+    .toFuture
   }
 }
 

--- a/server/app/controllers/BalancesController.scala
+++ b/server/app/controllers/BalancesController.scala
@@ -1,10 +1,12 @@
 package controllers
 
+import com.alexitc.playsonify.core.FutureOr.Implicits.FutureOps
 import com.alexitc.playsonify.models.ordering.OrderingQuery
 import com.alexitc.playsonify.models.pagination.{Limit, Offset, PaginatedQuery}
 import com.xsn.explorer.services.BalanceService
 import controllers.common.{Codecs, MyJsonController, MyJsonControllerComponents}
 import javax.inject.Inject
+import play.api.libs.json.{Json}
 
 class BalancesController @Inject()(balanceService: BalanceService, cc: MyJsonControllerComponents)
     extends MyJsonController(cc) {
@@ -13,5 +15,12 @@ class BalancesController @Inject()(balanceService: BalanceService, cc: MyJsonCon
 
   def getHighest(limit: Int, lastSeenAddress: Option[String]) = public { _ =>
     balanceService.getHighest(Limit(limit), lastSeenAddress)
+    .toFutureOr
+    .map {
+      value =>
+        val response = Ok(Json.toJson(value))
+        response.withHeaders("Cache-Control" -> "public, max-age=60")
+    }
+    .toFuture
   }
 }

--- a/server/app/controllers/BlocksController.scala
+++ b/server/app/controllers/BlocksController.scala
@@ -23,6 +23,13 @@ class BlocksController @Inject()(
 
   def getLatestBlocks() = public { _ =>
     blockService.getLatestBlocks()
+    .toFutureOr
+    .map {
+      value =>
+        val response = Ok(Json.toJson(value))
+        response.withHeaders("Cache-Control" -> "public, max-age=60")
+    }
+    .toFuture
   }
 
   def getBlockHeaders(lastSeenHash: Option[String], limit: Int, orderingCondition: String) = public { _ =>
@@ -74,6 +81,13 @@ class BlocksController @Inject()(
       .map(Height.apply)
       .map(blockService.getDetails)
       .getOrElse(blockService.getDetails(query))
+      .toFutureOr
+      .map {
+        value =>
+          val response = Ok(Json.toJson(value))
+          response.withHeaders("Cache-Control" -> "public, max-age=60")
+      }
+      .toFuture
   }
 
   def getRawBlock(query: String) = public { _ =>
@@ -81,18 +95,46 @@ class BlocksController @Inject()(
       .map(Height.apply)
       .map(blockService.getRawBlock)
       .getOrElse(blockService.getRawBlock(query))
+      .toFutureOr
+      .map {
+        value =>
+          val response = Ok(Json.toJson(value))
+          response.withHeaders("Cache-Control" -> "public, max-age=60")
+      }
+      .toFuture
   }
 
   def getTransactionsV2(blockhash: String, limit: Int, lastSeenTxid: Option[String]) = public { _ =>
     transactionService.getByBlockhash(blockhash, Limit(limit), lastSeenTxid)
+    .toFutureOr
+    .map {
+      value =>
+        val response = Ok(Json.toJson(value))
+        response.withHeaders("Cache-Control" -> "public, max-age=60")
+    }
+    .toFuture
   }
 
   def getLightTransactionsV2(blockhash: String, limit: Int, lastSeenTxid: Option[String]) = public { _ =>
     transactionService.getLightWalletTransactionsByBlockhash(blockhash, Limit(limit), lastSeenTxid)
+    .toFutureOr
+    .map {
+      value =>
+        val response = Ok(Json.toJson(value))
+        response.withHeaders("Cache-Control" -> "public, max-age=60")
+    }
+    .toFuture
   }
 
   def estimateFee(nBlocks: Int) = public { _ =>
     blockService.estimateFee(nBlocks)
+    .toFutureOr
+    .map {
+      value =>
+        val response = Ok(Json.toJson(value))
+        response.withHeaders("Cache-Control" -> "public, max-age=60")
+    }
+    .toFuture
   }
 
   def getBlockLite(blockhash: String) = public { _ =>

--- a/server/app/controllers/MasternodesController.scala
+++ b/server/app/controllers/MasternodesController.scala
@@ -1,10 +1,12 @@
 package controllers
 
+import com.alexitc.playsonify.core.FutureOr.Implicits.FutureOps
 import com.alexitc.playsonify.models.ordering.OrderingQuery
 import com.alexitc.playsonify.models.pagination.{Limit, Offset, PaginatedQuery}
 import com.xsn.explorer.services.MasternodeService
 import controllers.common.{Codecs, MyJsonController, MyJsonControllerComponents}
 import javax.inject.Inject
+import play.api.libs.json.{Json}
 
 class MasternodesController @Inject()(masternodeService: MasternodeService, cc: MyJsonControllerComponents)
     extends MyJsonController(cc) {
@@ -16,9 +18,23 @@ class MasternodesController @Inject()(masternodeService: MasternodeService, cc: 
     val orderingQuery = OrderingQuery(ordering)
 
     masternodeService.getMasternodes(paginatedQuery, orderingQuery)
+    .toFutureOr
+    .map {
+      value =>
+        val response = Ok(Json.toJson(value))
+        response.withHeaders("Cache-Control" -> "public, max-age=60")
+    }
+    .toFuture
   }
 
   def getBy(ipAddress: String) = public { _ =>
     masternodeService.getMasternode(ipAddress)
+    .toFutureOr
+    .map {
+      value =>
+        val response = Ok(Json.toJson(value))
+        response.withHeaders("Cache-Control" -> "public, max-age=60")
+    }
+    .toFuture
   }
 }

--- a/server/app/controllers/StatisticsController.scala
+++ b/server/app/controllers/StatisticsController.scala
@@ -1,17 +1,33 @@
 package controllers
 
+import com.alexitc.playsonify.core.FutureOr.Implicits.FutureOps
 import com.xsn.explorer.services.StatisticsService
 import controllers.common.{MyJsonController, MyJsonControllerComponents}
 import javax.inject.Inject
+import play.api.libs.json.{Json}
 
 class StatisticsController @Inject()(statisticsService: StatisticsService, cc: MyJsonControllerComponents)
     extends MyJsonController(cc) {
 
   def getStatus() = public { _ =>
     statisticsService.getStatistics()
+    .toFutureOr
+    .map {
+      value =>
+        val response = Ok(Json.toJson(value))
+        response.withHeaders("Cache-Control" -> "public, max-age=60")
+    }
+    .toFuture
   }
 
   def getBlockRewardsSummary() = public { _ =>
     statisticsService.getRewardsSummary(1000)
+    .toFutureOr
+    .map {
+      value =>
+        val response = Ok(Json.toJson(value))
+        response.withHeaders("Cache-Control" -> "public, max-age=60")
+    }
+    .toFuture
   }
 }

--- a/server/app/controllers/TransactionsController.scala
+++ b/server/app/controllers/TransactionsController.scala
@@ -14,10 +14,24 @@ class TransactionsController @Inject()(transactionRPCService: TransactionRPCServ
 
   def getTransaction(txid: String) = public { _ =>
     transactionRPCService.getTransactionDetails(txid)
+    .toFutureOr
+    .map {
+      value =>
+        val response = Ok(Json.toJson(value))
+        response.withHeaders("Cache-Control" -> "public, max-age=60")
+    }
+    .toFuture
   }
 
   def getRawTransaction(txid: String) = public { _ =>
     transactionRPCService.getRawTransaction(txid)
+    .toFutureOr
+    .map {
+      value =>
+        val response = Ok(Json.toJson(value))
+        response.withHeaders("Cache-Control" -> "public, max-age=60")
+    }
+    .toFuture
   }
 
   def sendRawTransaction() = publicInput { ctx: HasModel[SendRawTransactionRequest] =>
@@ -42,5 +56,12 @@ class TransactionsController @Inject()(transactionRPCService: TransactionRPCServ
 
   def getTransactionUtxoByIndex(txid: String, index: Int, includeMempool: Boolean) = public { _ =>
     transactionRPCService.getTransactionUtxoByIndex(txid, index, includeMempool)
+    .toFutureOr
+    .map {
+      value =>
+        val response = Ok(Json.toJson(value))
+        response.withHeaders("Cache-Control" -> "public, max-age=60")
+    }
+    .toFuture
   }
 }


### PR DESCRIPTION
### Problem

Server endpoints respond with the same information in shorts lapses.

### Solution

Add cache to endpoints to only refresh after a minute.

### Result

Endpoints work normally with an extra header to handle cache.

