### PR TITLE
server: Handle missing inputs error when sending a raw transaction

### DIFF
--- a/server/app/com/xsn/explorer/errors/TransactionError.scala
+++ b/server/app/com/xsn/explorer/errors/TransactionError.scala
@@ -71,4 +71,16 @@ object TransactionError {
       List(error)
     }
   }
+
+  final case object MissingInputs extends TransactionError with ConflictError {
+
+    // This is done this way because previously missing inputs error was not being handled so it ended up as
+    // an XSNMessageError("missing inputs") and the wallet team requested us not to change the response
+    // of the endpoint in those cases. But at the same time we did not want to keep it as an XSNMessageError
+    // since those are sent to sentry.
+    override def toPublicErrorList[L](i18nService: I18nService[L])(implicit lang: L): List[PublicError] = {
+      val error = GenericPublicError("missing inputs")
+      List(error)
+    }
+  }
 }

--- a/server/app/com/xsn/explorer/services/XSNService.scala
+++ b/server/app/com/xsn/explorer/services/XSNService.scala
@@ -591,6 +591,7 @@ class XSNServiceRPCImpl @Inject()(
   override def sendRawTransaction(hex: HexString): FutureApplicationResult[String] = {
     val errorCodeMapper = Map(
       -26 -> TransactionError.InvalidRawTransaction,
+      -25 -> TransactionError.MissingInputs,
       -22 -> TransactionError.InvalidRawTransaction,
       -27 -> TransactionError.RawTransactionAlreadyExists
     )


### PR DESCRIPTION
The endpoint response was left as it was before at the request of
the wallet team but now it has a status code of 409(conflict) instead
of 500(internal server error) and its no longer sent to sentry.